### PR TITLE
Allow nodes and edges to be dragged in interactive demo (#27)

### DIFF
--- a/demo-d3.html
+++ b/demo-d3.html
@@ -40,10 +40,22 @@
   font: 300 16px "Helvetica Neue";
 }
 
+.node:hover {
+	cursor: pointer;
+	opacity: 0.4;
+	filter: alpha(opacity=40);
+}
+
 path.edge {
   fill: none;
   stroke: #333;
   stroke-width: 1.5px;
+}
+
+.edge:hover {
+	cursor: pointer;
+	opacity: 0.4;
+	filter: alpha(opacity=40);
 }
 </style>
 
@@ -105,7 +117,7 @@ path.edge {
     .enter()
       .append("g")
       .attr("class", "node")
-      .attr("id", function(d) { return "node-" + d.label });
+			.attr("id", function(d) { return "node-" + d.label });
 
   var edges = svgGroup
     .selectAll("path .edge")
@@ -113,7 +125,7 @@ path.edge {
     .enter()
       .append("path")
       .attr("class", "edge")
-      .attr("marker-end", "url(#arrowhead)");
+			.attr("marker-end", "url(#arrowhead)");
 
   // Append rectangles to the nodes. We do this before laying out the text
   // because we want the text above the rectangle.
@@ -149,28 +161,81 @@ path.edge {
     .attr("x", function(d) { return -d.bbox.width / 2; })
     .attr("y", function(d) { return -d.bbox.height / 2; });
 
-  dagre.layout()
+	// Create the layout and get the graph
+  var graph = dagre.layout()
     .nodeSep(50)
     .edgeSep(10)
     .rankSep(50)
     .nodes(states)
     .edges(transitions)
     .debugLevel(1)
-    .run();
+	.run()
+	.graph();
 
-  nodes.attr("transform", function(d) { return "translate(" + d.dagre.x + "," + d.dagre.y +")"; });
+	nodes.attr("transform", function(d) { return 'translate('+ d.dagre.x +','+ d.dagre.y +')'; });
 
-  edges.attr("d", function(e) {
-    var points = e.dagre.points;
-    var source = dagre.util.intersectRect(e.source.dagre, points.length > 0 ? points[0] : e.source.dagre);
-    var target = dagre.util.intersectRect(e.target.dagre, points.length > 0 ? points[points.length - 1] : e.source.dagre);
-    points.unshift(source);
-    points.push(target);
-    return spline(points);
-  });
+	edges
+		// Set the id. of the SVG element to have access to it later
+		.attr('id', function(e) { return e.dagre.id; })
+		.attr("d", function(e) {
+			var points = e.dagre.points;
+			var source = dagre.util.intersectRect(e.source.dagre, points.length > 0 ? points[0] : e.source.dagre);
+			var target = dagre.util.intersectRect(e.target.dagre, points.length > 0 ? points[points.length - 1] : e.source.dagre);
+			points.unshift(source);
+			points.push(target);
+			return spline(points);
+		});
 
-  // Resize the SVG element
-  var svgBBox = svg.node().getBBox();
-  svg.attr("width", svgBBox.width + 10);
-  svg.attr("height", svgBBox.height + 10);
+	// Resize the SVG element
+	var svgBBox = svg.node().getBBox();
+	svg.attr("width", svgBBox.width + 10);
+	svg.attr("height", svgBBox.height + 10);
+
+	// Drag handlers
+	var nodeDrag = d3.behavior.drag()
+		// Set the right origin (based on the Dagre layout or the current position)
+		.origin(function(d) { return d.pos ? {x: d.pos.x, y: d.pos.y} : {x: d.dagre.x, y: d.dagre.y}; })
+		.on('drag', function (d, i) {
+			// Store the current node position without overwriting the original Dagre value
+			d.pos || (d.pos = {x: d.dagre.x, y: d.dagre.y});
+
+			// The node must be inside the SVG area
+			d.pos.x = Math.max(d.width / 2, Math.min(svgBBox.width - d.width / 2, d3.event.x));
+			d.pos.y = Math.max(d.height / 2, Math.min(svgBBox.height - d.height / 2, d3.event.y));
+			d3.select(this).attr('transform', 'translate('+ d.pos.x +','+ d.pos.y +')');
+
+			// Edges position (inside SVG area)
+			graph.inEdges(d.dagre.id).forEach(function(edgeId) {
+				d3.select('#'+ edgeId).attr('d', function(edge) {
+					for (var i = 1, p = edge.dagre.points; i < p.length; i++)
+						p[i] = {x: p[i].x + d3.event.dx, y: p[i].y + d3.event.dy};
+
+					return spline(p);
+				});
+			});
+			graph.outEdges(d.dagre.id).forEach(function(edgeId) {
+				d3.select('#'+ edgeId).attr('d', function(edge) {
+					for (var i = 0, p = edge.dagre.points; i < p.length - 1; i++)
+						p[i] = {x: p[i].x + d3.event.dx, y: p[i].y + d3.event.dy};
+
+					return spline(p);
+				});
+			});
+		});
+
+	var edgeDrag = d3.behavior.drag()
+		.on('drag', function (d, i) {
+			d3.select(this).attr('d', function() {
+				for (var i = 1, p= d.dagre.points; i < p.length - 1; i++)
+					p[i] = {
+						x: Math.max(0, Math.min(svgBBox.width, p[i].x + d3.event.dx)),
+						y: Math.max(0, Math.min(svgBBox.height, p[i].y + d3.event.dy))
+					};
+
+				return spline(p);
+			});
+		});
+
+	nodes.call(nodeDrag);
+	edges.call(edgeDrag);
 </script>

--- a/src/graph.js
+++ b/src/graph.js
@@ -108,6 +108,11 @@ dagre.graph = function() {
     }
   }
 
+	/*
+	 * Return all edges with no arguments,
+	 * the ones that are incident on a node (one argument),
+	 * or all edges from a source to a target (two arguments)
+	 */
   graph.edges = function(u, v) {
     var es, sourceEdges;
     if (!arguments.length) {
@@ -132,11 +137,17 @@ dagre.graph = function() {
     }
   }
 
+	/*
+	 * Return all in edges to a target node
+	 */
   graph.inEdges = function(target) {
     strictGetNode(target);
     return concat(values(inEdges[target]).map(function(es) { return keys(es.edges); }));
   };
 
+	/*
+	 * Return all out edges to a target node
+	 */
   graph.outEdges = function(source) {
     strictGetNode(source);
     return concat(values(outEdges[source]).map(function(es) { return keys(es.edges); }));

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -9,6 +9,9 @@ dagre.layout = function() {
       debugLevel = 0,
       timer = createTimer();
 
+	// Graph
+	var g = dagre.graph();
+
   // Phase functions
   var
       acyclic = dagre.layout.acyclic(),
@@ -74,12 +77,14 @@ dagre.layout = function() {
 
   self.run = timer.wrap("Total layout", run);
 
+	self.graph = function() {
+		return g;
+	};
+
   return self;
 
   // Build graph and save mapping of generated ids to original nodes and edges
   function init() {
-    var g = dagre.graph();
-
     var nextId = 0;
 
     // Tag each node so that we can properly represent relationships when
@@ -109,6 +114,7 @@ dagre.layout = function() {
       // loops, so they can be skipped.
       if (source !== target) {
         var id = "id" in e ? e.id : "_E" + nextId++;
+        e.dagre.id = id;
         e.dagre.minLen = e.minLen || 1;
         e.dagre.width = e.width || 0;
         e.dagre.height = e.height || 0;
@@ -165,6 +171,8 @@ dagre.layout = function() {
       acyclic.undo(g);
     } finally {
       self.rankSep(rankSep);
+
+      return self;
     }
   }
 


### PR DESCRIPTION
I've added the interaction, but I've left room for improvements.

Also:
- Added dagre.layout.graph(), which returns the current graph (it's useful for managing nodes and edges)
- Set dagre.layout.run() chainable
- dagre.layout.init() saves the edge id. for later using it inside SVG elements (to handle them properly)
- Added some comments to dagre.graph methods
