### PR TITLE
Rank constraints

### DIFF
--- a/lib/acyclic.js
+++ b/lib/acyclic.js
@@ -8,13 +8,17 @@ function acyclic(g, debugLevel) {
 
   function dfs(u) {
     if (u in visited) return;
+    var fromMax = g.node(u).hasOwnProperty("prefRank") &&
+      g.node(u).prefRank === "max";
 
     visited[u] = onStack[u] = true;
     g.outEdges(u).forEach(function(e) {
       var t = g.target(e),
           a;
+      var toMin = g.node(t).hasOwnProperty("prefRank") &&
+        g.node(t).prefRank === "min";
 
-      if (t in onStack) {
+      if (t in onStack || fromMax || toMin) {
         a = g.edge(e);
         g.delEdge(e);
         a.reversed = true;

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -64,7 +64,7 @@ module.exports = function() {
         width: value.width,
         height: value.height
       });
-      if (value.hasOwnProperty('rank')) {
+      if (value.hasOwnProperty("rank")) {
         g.node(u).prefRank = value.rank;
       }
     });

--- a/lib/rank.js
+++ b/lib/rank.js
@@ -32,7 +32,7 @@ function combineRanks(g) {
   var ranks = {};
   var uid = 1;
   g.eachNode(function(n, value) {
-    if (value.hasOwnProperty('prefRank')) {
+    if (value.hasOwnProperty("prefRank")) {
       hasRankConstraint = true;
       var preferredRank = value.prefRank;
       if (!ranks.hasOwnProperty(preferredRank)) {
@@ -41,7 +41,7 @@ function combineRanks(g) {
       ranks[preferredRank].push(n);
     } else {
       // Nodes with no rank constraint get their own rank id
-      var ur = 'unconstrained_rank_' + uid++;
+      var ur = "unconstrained_rank_" + uid++;
       ranks[ur] = [n];
       if (g.node(n)) {
         g.node(n).prefRank = ur;
@@ -64,42 +64,25 @@ function combineRanks(g) {
     g.eachEdge(function(id, source, target, value) {
       var source_pref = g.node(source).prefRank;
       var target_pref = g.node(target).prefRank;
-      console.log('source: ' + source + ' rank: ' + source_pref);
-      console.log('target: ' + target + ' rank: ' + target_pref);
-      if (source_pref != target_pref) {
+      if (source_pref !== target_pref) {
         reduced.addEdge(null, source_pref, target_pref, {minLen: value.minLen});
       }
     });
 
-    // Reverse in-edges into the minimum rank node and out-edges from
-    // the maximum rank node.
-    function reverse(edges) {
-      for (var e in edges) {
-        var edge = edges[e];
-        var source = reduced.source(edges[e]);
-        var target = reduced.target(edges[e]);
-        var minLen = reduced.edge(e).minLen;
-        reduced.delEdge(edges[e]);
-        reduced.addEdge(edges[e], target, source, {reversed: true, minLen: minLen});
-      }
-    };
-
-    if (reduced.hasNode('min')) {
-      reverse(reduced.inEdges('min'));
-      // Add edges from 'min' to any node without in-edges.
-      reduced.eachNode(function(n, value) {
-        if (n != 'min' && n != 'max' && reduced.inEdges(n).length == 0) {
-          reduced.addEdge(null, 'min', n, {minLen: 1});
+    if (reduced.hasNode("min")) {
+      // Add edges from "min" to any node without in-edges.
+      reduced.eachNode(function(n) {
+        if (n !== "min" && n !== "max" && reduced.inEdges(n).length === 0) {
+          reduced.addEdge(null, "min", n, {internal: true, minLen: 1});
         }
       });
     }
 
-    if (reduced.hasNode('max')) {
-      reverse(reduced.outEdges('max'));
-      // Add edges from any node without out-edges to 'max'.
-      reduced.eachNode(function(n, value) {
-        if (n != 'max' && reduced.outEdges(n).length == 0) {
-          reduced.addEdge(null, n, 'max', {minLen: 1});
+    if (reduced.hasNode("max")) {
+      // Add edges from any node without out-edges to "max".
+      reduced.eachNode(function(n) {
+        if (n !== "max" && reduced.outEdges(n).length === 0) {
+          reduced.addEdge(null, n, "max", {internal: true, minLen: 1});
         }
       });
     }
@@ -110,14 +93,15 @@ function combineRanks(g) {
   }
 }
 
+// If the argument graph was a reduced version of some original graph
+// then copy assigned ranks from it to the original.  Otherwise, the
+// ranks are already assigned.
 function expandRanks(reduced) {
   if (reduced.graph() && reduced.graph().originalGraph) {
-    // Copy ranks from reduced graph nodes to original graph
-    // nodes.
     var expanded = reduced.graph().originalGraph;
     reduced.eachNode(function(n, value) {
-      for (var n in value.originals) {
-        expanded.node(value.originals[n]).rank = value.rank;
+      for (var o in value.originals) {
+        expanded.node(value.originals[o]).rank = value.rank;
       }
     });
     return expanded;

--- a/test/acyclic-test.js
+++ b/test/acyclic-test.js
@@ -41,6 +41,20 @@ describe("acyclic", function() {
     acyclic(g);
     assertAcyclic(g);
   });
+
+  it("reverses edges to 'min' nodes", function() {
+    var g = dot.parse("digraph { A [prefRank = \"min\"]; B -> A }");
+    acyclic(g);
+    assert.deepEqual(g.successors("A"), ["B"]);
+    assertAcyclic(g);
+  });
+
+  it("reverses edges from 'max' nodes", function() {
+    var g = dot.parse("digraph { B [prefRank = \"max\"]; B -> A }");
+    acyclic(g);
+    assert.deepEqual(g.successors("A"), ["B"]);
+    assertAcyclic(g);
+  });
 });
 
 function assertAcyclic(g) {

--- a/test/rank-test.js
+++ b/test/rank-test.js
@@ -49,5 +49,32 @@ describe("layout/rank", function() {
     assert.equal(g.node("A").rank, 0);
     assert.notProperty(g.node("sg1"), "rank");
   });
+
+  it("ranks the 'min' node before any others", function() {
+    var g = dot.parse("digraph { A; B [prefRank = \"min\"]; C; }");
+
+    rank(g);
+
+    assert(g.node("B").rank < g.node("A").rank, "rank of B not less than rank of A");
+    assert(g.node("B").rank < g.node("C").rank, "rank of B not less than rank of C");
+  });
+
+  it("ranks the 'max' node after any others", function() {
+    var g = dot.parse("digraph { A; B [prefRank = \"max\"]; C; }");
+
+    rank(g);
+
+    assert(g.node("B").rank > g.node("A").rank, "rank of B not greater than rank of A");
+    assert(g.node("B").rank > g.node("C").rank, "rank of B not greater than rank of C");
+  });
+
+  it("gives the same rank to nodes with the same preference", function() {
+    var g = dot.parse("digraph { A [prefRank = 1]; B [prefRank = 1]; C [prefRank = 2]; D [prefRank = 2]; A -> B; D -> C; }");
+
+    rank(g);
+
+    assert.equal(g.node("A").rank, g.node("B").rank);
+    assert.equal(g.node("C").rank, g.node("D").rank);
+  });
 });
 


### PR DESCRIPTION
Here is the set of changes to constrain node ranks.  In a Dot file, constraints appear as a [rank = "label"] property with distinguished "min" and "max" labels.  Internal to the layout code, the property is called prefRank.
