### PR TITLE
Remove ignore on dagre.js and dagre.min.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,6 @@
     "CHANGELOG.md",
     "Makefile",
     "browser.js",
-    "dist/dagre.js",
-    "dist/dagre.min.js",
     "index.js",
     "karma*",
     "lib/**",


### PR DESCRIPTION
bower install dagre does not grab these 2 files because they are ignored. However the npm install does.
Hope this makes sense.