### PR TITLE
Allow positioner to be configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ module.exports = {
   debug: require("./lib/debug"),
   util: {
     time: require("./lib/util").time,
-    notime: require("./lib/util").notime
+    notime: require("./lib/util").notime,
+    buildLayerMatrix: require("./lib/util").buildLayerMatrix
   },
   version: require("./lib/version")
 };

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -96,7 +96,7 @@ function updateInputGraph(inputGraph, layoutGraph) {
 
 var graphNumAttrs = ["nodesep", "edgesep", "ranksep", "marginx", "marginy"];
 var graphDefaults = { ranksep: 50, edgesep: 20, nodesep: 50, rankdir: "tb" };
-var graphAttrs = ["acyclicer", "ranker", "rankdir", "align"];
+var graphAttrs = ["acyclicer", "ranker", "positioner", "rankdir", "align"];
 var nodeNumAttrs = ["width", "height"];
 var nodeDefaults = { width: 0, height: 0 };
 var edgeNumAttrs = ["minlen", "weight", "width", "height", "labeloffset"];

--- a/lib/position/index.js
+++ b/lib/position/index.js
@@ -9,6 +9,11 @@ module.exports = position;
 function position(g) {
   g = util.asNonCompoundGraph(g);
 
+  var positioner = g.graph().positioner;
+  if (positioner instanceof Function) {
+    return positioner(g)
+  }
+
   positionY(g);
   _.forEach(positionX(g), function(x, v) {
     g.node(v).x = x;


### PR DESCRIPTION
This adds an option for g.graph().positioner to be a custom function and makes positioner a graph attribute.
It also enables exporting util.buildLayerMatrix.