### PR TITLE
Export node order

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -71,6 +71,7 @@ function updateInputGraph(inputGraph, layoutGraph) {
     if (inputLabel) {
       inputLabel.x = layoutLabel.x;
       inputLabel.y = layoutLabel.y;
+      inputLabel.order = layoutLabel.order;
 
       if (layoutGraph.children(v).length) {
         inputLabel.width = layoutLabel.width;


### PR DESCRIPTION
This exports node order as an inputLabel attribute. 
(For example, this allows special handling for the case of side-by-side nodes.)