### PR TITLE
Remove all comments except the license notice when minifying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,13 @@ $(BUILD_DIR)/$(MOD).js: index.js $(SRC_FILES) | unit-test
 	@$(BROWSERIFY) $< > $@ -s dagre
 
 $(BUILD_DIR)/$(MOD).min.js: $(BUILD_DIR)/$(MOD).js
-	@$(UGLIFY) $< --comments '@license' > $@
+	@$(UGLIFY) $< --comments > $@
 
 $(BUILD_DIR)/$(MOD).core.js: index.js $(SRC_FILES) | unit-test
 	@$(BROWSERIFY) $< > $@ --no-bundle-external -s dagre
 
 $(BUILD_DIR)/$(MOD).core.min.js: $(BUILD_DIR)/$(MOD).core.js
-	@$(UGLIFY) $< --comments '@license' > $@
+	@$(UGLIFY) $< --comments > $@
 
 dist: $(BUILD_FILES) | bower.json test
 	@rm -rf $@

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /*
+@license
 Copyright (c) 2012-2014 Chris Pettitt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Configure Uglify to remove all comments, while keeping the license text.
This solves both issues #265 and #203 