### PR TITLE
[Ordering] add ability to define order constraints within rank

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -17,17 +17,18 @@ var Graph = require("./graphlib").Graph;
 
 module.exports = layout;
 
-function layout(g, opts) {
-  var time = opts && opts.debugTiming ? util.time : util.notime;
+function layout(g, inputOpts) {
+  var opts = inputOpts || {}; 
+  var time = opts.debugTiming ? util.time : util.notime;
   time("layout", function() {
     var layoutGraph = 
       time("  buildLayoutGraph", function() { return buildLayoutGraph(g); });
-    time("  runLayout",        function() { runLayout(layoutGraph, time); });
+    time("  runLayout",        function() { runLayout(layoutGraph, time, opts); });
     time("  updateInputGraph", function() { updateInputGraph(g, layoutGraph); });
   });
 }
 
-function runLayout(g, time) {
+function runLayout(g, time, opts) {
   time("    makeSpaceForEdgeLabels", function() { makeSpaceForEdgeLabels(g); });
   time("    removeSelfEdges",        function() { removeSelfEdges(g); });
   time("    acyclic",                function() { acyclic.run(g); });
@@ -42,7 +43,7 @@ function runLayout(g, time) {
   time("    normalize.run",          function() { normalize.run(g); });
   time("    parentDummyChains",      function() { parentDummyChains(g); });
   time("    addBorderSegments",      function() { addBorderSegments(g); });
-  time("    order",                  function() { order(g); });
+  time("    order",                  function() { order(g, opts); });
   time("    insertSelfEdges",        function() { insertSelfEdges(g); });
   time("    adjustCoordinateSystem", function() { coordinateSystem.adjust(g); });
   time("    position",               function() { position(g); });

--- a/lib/order/index.js
+++ b/lib/order/index.js
@@ -25,8 +25,9 @@ module.exports = order;
  *
  *    1. Graph nodes will have an "order" attribute based on the results of the
  *       algorithm.
+ * 
  */
-function order(g) {
+function order(g, opts) {
   var maxRank = util.maxRank(g),
     downLayerGraphs = buildLayerGraphs(g, _.range(1, maxRank + 1), "inEdges"),
     upLayerGraphs = buildLayerGraphs(g, _.range(maxRank - 1, -1, -1), "outEdges");
@@ -37,8 +38,12 @@ function order(g) {
   var bestCC = Number.POSITIVE_INFINITY,
     best;
 
-  for (var i = 0, lastBest = 0; lastBest < 4; ++i, ++lastBest) {
-    sweepLayerGraphs(i % 2 ? downLayerGraphs : upLayerGraphs, i % 4 >= 2);
+  var constraints = opts.constraints || [];
+
+  for (var i = 0, lastBest = 0; lastBest < 2; ++i, ++lastBest) {
+    var biasRight = i % 2 === 1;
+    sweepLayerGraphs(downLayerGraphs, biasRight, constraints);
+    sweepLayerGraphs(upLayerGraphs, biasRight, constraints);
 
     layering = util.buildLayerMatrix(g);
     var cc = crossCount(g, layering);
@@ -58,8 +63,13 @@ function buildLayerGraphs(g, ranks, relationship) {
   });
 }
 
-function sweepLayerGraphs(layerGraphs, biasRight) {
+function sweepLayerGraphs(layerGraphs, biasRight, constraints) {
   var cg = new Graph();
+
+  _.forEach(constraints, function(constraint) {
+    cg.setEdge(constraint.left, constraint.right);
+  });
+
   _.forEach(layerGraphs, function(lg) {
     var root = lg.graph().root;
     var sorted = sortSubgraph(lg, root, cg, biasRight);


### PR DESCRIPTION
Allows for node order constraints like:
```js
dagre.layout(g, {constraints: [{left: "node-B", right: "node-A"}]})
```

Addresses: https://github.com/dagrejs/dagre/issues/112, https://github.com/dagrejs/dagre/issues/201, https://github.com/dagrejs/dagre/issues/251, among others
Related PRs: https://github.com/dagrejs/dagre/pull/263, https://github.com/dagrejs/dagre/pull/252


## Usage
```ts
interface Constraint {
    left: string;
    right: string;
}

interface Options {
    constraints?: Constraint[];
}

function layout(g: graphlib.Graph, opts: Options) {...}
```

## Example
Without constraints:
![](https://cl.ly/3b4acc581b48/Image%2525202020-06-02%252520at%2525203.25.42%252520PM.png)

With constraints:
![](https://cl.ly/11f0af771571/Image%202020-06-02%20at%203.28.52%20PM.png)

```ts
const g = new dagre.graphlib.Graph({}).setGraph({}).setDefaultEdgeLabel(function () {
    return {}
})
g.setNode("root")
g.setNode("node-A")
g.setNode("node-B")
g.setEdge("root", "node-A")
g.setEdge("root", "node-B")
dagre.layout(g, {constraints: [{left: "node-B", right: "node-A"}]})
```


## Details

I'm following a suggestion made by @cpettitt in https://github.com/dagrejs/dagre-d3/issues/64#issuecomment-52138308

To specify the constraints, I'm following the `opts` approach used in https://github.com/dagrejs/dagre/pull/263, but open to suggestions.
