### PR TITLE
Recursive DFS implementations

### DIFF
--- a/lib/acyclic.js
+++ b/lib/acyclic.js
@@ -5,13 +5,13 @@ var greedyFAS = require("./greedy-fas");
 
 module.exports = {
   run: run,
-  undo: undo,
+  undo: undo
 };
 
 function run(g) {
   var fas =
     g.graph().acyclicer === "greedy" ? greedyFAS(g, weightFn(g)) : dfsFAS(g);
-  _.forEach(fas, function (e) {
+  _.forEach(fas, function(e) {
     var label = g.edge(e);
     g.removeEdge(e);
     label.forwardName = e.name;
@@ -20,7 +20,7 @@ function run(g) {
   });
 
   function weightFn(g) {
-    return function (e) {
+    return function(e) {
       return g.edge(e).weight;
     };
   }
@@ -58,7 +58,7 @@ function dfsFAS(g) {
 }
 
 function undo(g) {
-  _.forEach(g.edges(), function (e) {
+  _.forEach(g.edges(), function(e) {
     var label = g.edge(e);
     if (label.reversed) {
       g.removeEdge(e);

--- a/lib/acyclic.js
+++ b/lib/acyclic.js
@@ -5,14 +5,13 @@ var greedyFAS = require("./greedy-fas");
 
 module.exports = {
   run: run,
-  undo: undo
+  undo: undo,
 };
 
 function run(g) {
-  var fas = (g.graph().acyclicer === "greedy"
-    ? greedyFAS(g, weightFn(g))
-    : dfsFAS(g));
-  _.forEach(fas, function(e) {
+  var fas =
+    g.graph().acyclicer === "greedy" ? greedyFAS(g, weightFn(g)) : dfsFAS(g);
+  _.forEach(fas, function (e) {
     var label = g.edge(e);
     g.removeEdge(e);
     label.forwardName = e.name;
@@ -21,7 +20,7 @@ function run(g) {
   });
 
   function weightFn(g) {
-    return function(e) {
+    return function (e) {
       return g.edge(e).weight;
     };
   }
@@ -33,19 +32,25 @@ function dfsFAS(g) {
   var visited = {};
 
   function dfs(v) {
-    if (_.has(visited, v)) {
-      return;
+    var s = [v];
+
+    while (s.length > 0) {
+      var curr = s.pop();
+
+      if (_.has(visited, curr)) continue;
+
+      visited[curr] = true;
+      stack[v] = true;
+      _.forEachRight(g.outEdges(curr), function (e) {
+        if (_.has(stack, e.w)) {
+          fas.push(e);
+        } else {
+          s.push(e.w);
+        }
+      });
+
+      delete stack[curr];
     }
-    visited[v] = true;
-    stack[v] = true;
-    _.forEach(g.outEdges(v), function(e) {
-      if (_.has(stack, e.w)) {
-        fas.push(e);
-      } else {
-        dfs(e.w);
-      }
-    });
-    delete stack[v];
   }
 
   _.forEach(g.nodes(), dfs);
@@ -53,7 +58,7 @@ function dfsFAS(g) {
 }
 
 function undo(g) {
-  _.forEach(g.edges(), function(e) {
+  _.forEach(g.edges(), function (e) {
     var label = g.edge(e);
     if (label.reversed) {
       g.removeEdge(e);

--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -15,7 +15,7 @@ if (typeof require === "function") {
       flatten: require("lodash/flatten"),
       forEach: require("lodash/forEach"),
       forIn: require("lodash/forIn"),
-      has:  require("lodash/has"),
+      has: require("lodash/has"),
       isUndefined: require("lodash/isUndefined"),
       last: require("lodash/last"),
       map: require("lodash/map"),
@@ -32,6 +32,7 @@ if (typeof require === "function") {
       uniqueId: require("lodash/uniqueId"),
       values: require("lodash/values"),
       zipObject: require("lodash/zipObject"),
+      forEachRight: require("lodash/forEachRight"),
     };
   } catch (e) {
     // continue regardless of error

--- a/lib/order/init-order.js
+++ b/lib/order/init-order.js
@@ -17,21 +17,35 @@ module.exports = initOrder;
  */
 function initOrder(g) {
   var visited = {};
-  var simpleNodes = _.filter(g.nodes(), function(v) {
+  var simpleNodes = _.filter(g.nodes(), function (v) {
     return !g.children(v).length;
   });
-  var maxRank = _.max(_.map(simpleNodes, function(v) { return g.node(v).rank; }));
-  var layers = _.map(_.range(maxRank + 1), function() { return []; });
+  var maxRank = _.max(
+    _.map(simpleNodes, function (v) {
+      return g.node(v).rank;
+    })
+  );
+  var layers = _.map(_.range(maxRank + 1), function () {
+    return [];
+  });
 
   function dfs(v) {
-    if (_.has(visited, v)) return;
-    visited[v] = true;
-    var node = g.node(v);
-    layers[node.rank].push(v);
-    _.forEach(g.successors(v), dfs);
+    var stack = [v];
+    while (stack.length > 0) {
+      var curr = stack.pop();
+      if (!_.has(visited, curr)) {
+        visited[curr] = true;
+        var node = g.node(curr);
+        layers[node.rank].push(curr);
+        _.forEachRight(g.successors(curr), function (w) {
+          stack.push(w);
+        });
+      }
+    }
   }
-
-  var orderedVs = _.sortBy(simpleNodes, function(v) { return g.node(v).rank; });
+  var orderedVs = _.sortBy(simpleNodes, function (v) {
+    return g.node(v).rank;
+  });
   _.forEach(orderedVs, dfs);
 
   return layers;

--- a/lib/order/init-order.js
+++ b/lib/order/init-order.js
@@ -17,17 +17,11 @@ module.exports = initOrder;
  */
 function initOrder(g) {
   var visited = {};
-  var simpleNodes = _.filter(g.nodes(), function (v) {
+  var simpleNodes = _.filter(g.nodes(), function(v) {
     return !g.children(v).length;
   });
-  var maxRank = _.max(
-    _.map(simpleNodes, function (v) {
-      return g.node(v).rank;
-    })
-  );
-  var layers = _.map(_.range(maxRank + 1), function () {
-    return [];
-  });
+  var maxRank = _.max(_.map(simpleNodes, function(v) { return g.node(v).rank; }));
+  var layers = _.map(_.range(maxRank + 1), function() { return []; });
 
   function dfs(v) {
     var stack = [v];
@@ -43,9 +37,7 @@ function initOrder(g) {
       }
     }
   }
-  var orderedVs = _.sortBy(simpleNodes, function (v) {
-    return g.node(v).rank;
-  });
+  var orderedVs = _.sortBy(simpleNodes, function(v) { return g.node(v).rank; });
   _.forEach(orderedVs, dfs);
 
   return layers;

--- a/lib/rank/feasible-tree.js
+++ b/lib/rank/feasible-tree.js
@@ -55,15 +55,21 @@ function feasibleTree(g) {
  */
 function tightTree(t, g) {
   function dfs(v) {
-    _.forEach(g.nodeEdges(v), function(e) {
-      var edgeV = e.v,
-        w = (v === edgeV) ? e.w : edgeV;
-      if (!t.hasNode(w) && !slack(g, e)) {
-        t.setNode(w, {});
-        t.setEdge(v, w, {});
-        dfs(w);
-      }
-    });
+    var stack = [v];
+
+    while (stack.length > 0) {
+      var curr = stack.pop();
+
+      _.forEachRight(g.nodeEdges(curr), function (e) {
+        var edgeV = e.v,
+          w = curr === edgeV ? e.w : edgeV;
+        if (!t.hasNode(w) && !slack(g, e)) {
+          t.setNode(w, {});
+          t.setEdge(curr, w, {});
+          stack.push(w);
+        }
+      });
+    }
   }
 
   _.forEach(t.nodes(), dfs);
@@ -75,7 +81,7 @@ function tightTree(t, g) {
  * it.
  */
 function findMinSlackEdge(t, g) {
-  return _.minBy(g.edges(), function(e) {
+  return _.minBy(g.edges(), function (e) {
     if (t.hasNode(e.v) !== t.hasNode(e.w)) {
       return slack(g, e);
     }
@@ -83,7 +89,7 @@ function findMinSlackEdge(t, g) {
 }
 
 function shiftRanks(t, g, delta) {
-  _.forEach(t.nodes(), function(v) {
+  _.forEach(t.nodes(), function (v) {
     g.node(v).rank += delta;
   });
 }

--- a/lib/rank/feasible-tree.js
+++ b/lib/rank/feasible-tree.js
@@ -60,7 +60,7 @@ function tightTree(t, g) {
     while (stack.length > 0) {
       var curr = stack.pop();
 
-      _.forEachRight(g.nodeEdges(curr), function (e) {
+      _.forEachRight(g.nodeEdges(curr), function(e) {
         var edgeV = e.v,
           w = curr === edgeV ? e.w : edgeV;
         if (!t.hasNode(w) && !slack(g, e)) {
@@ -81,7 +81,7 @@ function tightTree(t, g) {
  * it.
  */
 function findMinSlackEdge(t, g) {
-  return _.minBy(g.edges(), function (e) {
+  return _.minBy(g.edges(), function(e) {
     if (t.hasNode(e.v) !== t.hasNode(e.w)) {
       return slack(g, e);
     }
@@ -89,7 +89,5 @@ function findMinSlackEdge(t, g) {
 }
 
 function shiftRanks(t, g, delta) {
-  _.forEach(t.nodes(), function (v) {
-    g.node(v).rank += delta;
-  });
+  _.forEach(t.nodes(), function(v) { g.node(v).rank += delta; });
 }

--- a/lib/rank/network-simplex.js
+++ b/lib/rank/network-simplex.js
@@ -71,7 +71,7 @@ function networkSimplex(g) {
 function initCutValues(t, g) {
   var vs = postorder(t, t.nodes());
   vs = vs.slice(0, vs.length - 1);
-  _.forEach(vs, function (v) {
+  _.forEach(vs, function(v) {
     assignCutValue(t, g, v);
   });
 }
@@ -103,7 +103,7 @@ function calcCutValue(t, g, child) {
 
   cutValue = graphEdge.weight;
 
-  _.forEach(g.nodeEdges(child), function (e) {
+  _.forEach(g.nodeEdges(child), function(e) {
     var isOutEdge = e.v === child,
       other = isOutEdge ? e.w : e.v;
 
@@ -155,9 +155,7 @@ function dfsAssignLowLim(tree, visited, nextLim, v, parent) {
 }
 
 function leaveEdge(tree) {
-  return _.find(tree.edges(), function (e) {
-    return tree.edge(e).cutvalue < 0;
-  });
+  return _.find(tree.edges(), function(e) { return tree.edge(e).cutvalue < 0; });
 }
 
 function enterEdge(t, g, edge) {
@@ -184,16 +182,12 @@ function enterEdge(t, g, edge) {
     flip = true;
   }
 
-  var candidates = _.filter(g.edges(), function (edge) {
-    return (
-      flip === isDescendant(t, t.node(edge.v), tailLabel) &&
-      flip !== isDescendant(t, t.node(edge.w), tailLabel)
-    );
+  var candidates = _.filter(g.edges(), function(edge) {
+    return flip === isDescendant(t, t.node(edge.v), tailLabel) &&
+      flip !== isDescendant(t, t.node(edge.w), tailLabel);
   });
 
-  return _.minBy(candidates, function (edge) {
-    return slack(g, edge);
-  });
+  return _.minBy(candidates, function(edge) { return slack(g, edge); });
 }
 
 function exchangeEdges(t, g, e, f) {
@@ -212,7 +206,7 @@ function updateRanks(t, g) {
   });
   var vs = preorder(t, root);
   vs = vs.slice(1);
-  _.forEach(vs, function (v) {
+  _.forEach(vs, function(v) {
     var parent = t.node(v).parent,
       edge = g.edge(v, parent),
       flipped = false;
@@ -222,8 +216,7 @@ function updateRanks(t, g) {
       flipped = true;
     }
 
-    g.node(v).rank =
-      g.node(parent).rank + (flipped ? edge.minlen : -edge.minlen);
+    g.node(v).rank = g.node(parent).rank + (flipped ? edge.minlen : -edge.minlen);
   });
 }
 

--- a/lib/rank/network-simplex.js
+++ b/lib/rank/network-simplex.js
@@ -71,7 +71,7 @@ function networkSimplex(g) {
 function initCutValues(t, g) {
   var vs = postorder(t, t.nodes());
   vs = vs.slice(0, vs.length - 1);
-  _.forEach(vs, function(v) {
+  _.forEach(vs, function (v) {
     assignCutValue(t, g, v);
   });
 }
@@ -103,7 +103,7 @@ function calcCutValue(t, g, child) {
 
   cutValue = graphEdge.weight;
 
-  _.forEach(g.nodeEdges(child), function(e) {
+  _.forEach(g.nodeEdges(child), function (e) {
     var isOutEdge = e.v === child,
       other = isOutEdge ? e.w : e.v;
 
@@ -130,30 +130,32 @@ function initLowLimValues(tree, root) {
 }
 
 function dfsAssignLowLim(tree, visited, nextLim, v, parent) {
-  var low = nextLim;
-  var label = tree.node(v);
-
-  visited[v] = true;
-  _.forEach(tree.neighbors(v), function(w) {
-    if (!_.has(visited, w)) {
-      nextLim = dfsAssignLowLim(tree, visited, nextLim, w, v);
+  var stack = [[nextLim, { value: nextLim }, v, parent, false]];
+  while (stack.length > 0) {
+    var current = stack.pop();
+    if (current[4]) {
+      var label = tree.node(current[2]);
+      label.low = current[0];
+      label.lim = current[1].value++;
+      if (current[3]) {
+        label.parent = current[3];
+      } else {
+        delete label.parent;
+      }
+    } else if (!_.has(visited, current[2])) {
+      visited[current[2]] = true;
+      stack.push([current[1].value, current[1], current[2], current[3], true]);
+      _.forEachRight(tree.neighbors(current[2]), function (w) {
+        if (!_.has(visited, w)) {
+          stack.push([current[1].value, current[1], w, current[2], false]);
+        }
+      });
     }
-  });
-
-  label.low = low;
-  label.lim = nextLim++;
-  if (parent) {
-    label.parent = parent;
-  } else {
-    // TODO should be able to remove this when we incrementally update low lim
-    delete label.parent;
   }
-
-  return nextLim;
 }
 
 function leaveEdge(tree) {
-  return _.find(tree.edges(), function(e) {
+  return _.find(tree.edges(), function (e) {
     return tree.edge(e).cutvalue < 0;
   });
 }
@@ -182,12 +184,16 @@ function enterEdge(t, g, edge) {
     flip = true;
   }
 
-  var candidates = _.filter(g.edges(), function(edge) {
-    return flip === isDescendant(t, t.node(edge.v), tailLabel) &&
-           flip !== isDescendant(t, t.node(edge.w), tailLabel);
+  var candidates = _.filter(g.edges(), function (edge) {
+    return (
+      flip === isDescendant(t, t.node(edge.v), tailLabel) &&
+      flip !== isDescendant(t, t.node(edge.w), tailLabel)
+    );
   });
 
-  return _.minBy(candidates, function(edge) { return slack(g, edge); });
+  return _.minBy(candidates, function (edge) {
+    return slack(g, edge);
+  });
 }
 
 function exchangeEdges(t, g, e, f) {
@@ -201,10 +207,12 @@ function exchangeEdges(t, g, e, f) {
 }
 
 function updateRanks(t, g) {
-  var root = _.find(t.nodes(), function(v) { return !g.node(v).parent; });
+  var root = _.find(t.nodes(), function (v) {
+    return !g.node(v).parent;
+  });
   var vs = preorder(t, root);
   vs = vs.slice(1);
-  _.forEach(vs, function(v) {
+  _.forEach(vs, function (v) {
     var parent = t.node(v).parent,
       edge = g.edge(v, parent),
       flipped = false;
@@ -214,7 +222,8 @@ function updateRanks(t, g) {
       flipped = true;
     }
 
-    g.node(v).rank = g.node(parent).rank + (flipped ? edge.minlen : -edge.minlen);
+    g.node(v).rank =
+      g.node(parent).rank + (flipped ? edge.minlen : -edge.minlen);
   });
 }
 

--- a/lib/rank/util.js
+++ b/lib/rank/util.js
@@ -4,7 +4,7 @@ var _ = require("../lodash");
 
 module.exports = {
   longestPath: longestPath,
-  slack: slack,
+  slack: slack
 };
 
 /*
@@ -37,7 +37,7 @@ function longestPath(g) {
       var cur = stack.pop();
       if (cur[1]) {
         var rank = _.min(
-          _.map(g.outEdges(cur[0]), function (e) {
+          _.map(g.outEdges(cur[0]), function(e) {
             return g.node(e.w).rank - g.edge(e).minlen;
           })
         );
@@ -52,7 +52,7 @@ function longestPath(g) {
       } else if (!_.has(visited, cur[0])) {
         visited[cur[0]] = true;
         stack.push([cur[0], true]);
-        _.forEachRight(g.outEdges(cur[0]), function (e) {
+        _.forEachRight(g.outEdges(cur[0]), function(e) {
           stack.push([e.w, false]);
         });
       }

--- a/lib/rank/util.js
+++ b/lib/rank/util.js
@@ -4,7 +4,7 @@ var _ = require("../lodash");
 
 module.exports = {
   longestPath: longestPath,
-  slack: slack
+  slack: slack,
 };
 
 /*
@@ -32,23 +32,31 @@ function longestPath(g) {
   var visited = {};
 
   function dfs(v) {
-    var label = g.node(v);
-    if (_.has(visited, v)) {
-      return label.rank;
+    var stack = [[v, false]];
+    while (stack.length > 0) {
+      var cur = stack.pop();
+      if (cur[1]) {
+        var rank = _.min(
+          _.map(g.outEdges(cur[0]), function (e) {
+            return g.node(e.w).rank - g.edge(e).minlen;
+          })
+        );
+        if (
+          rank === Number.POSITIVE_INFINITY ||
+          rank === undefined ||
+          rank === null
+        ) {
+          rank = 0;
+        }
+        g.node(cur[0]).rank = rank;
+      } else if (!_.has(visited, cur[0])) {
+        visited[cur[0]] = true;
+        stack.push([cur[0], true]);
+        _.forEachRight(g.outEdges(cur[0]), function (e) {
+          stack.push([e.w, false]);
+        });
+      }
     }
-    visited[v] = true;
-
-    var rank = _.min(_.map(g.outEdges(v), function(e) {
-      return dfs(e.w) - g.edge(e).minlen;
-    }));
-
-    if (rank === Number.POSITIVE_INFINITY || // return value of _.map([]) for Lodash 3
-        rank === undefined || // return value of _.map([]) for Lodash 4
-        rank === null) { // return value of _.map([null])
-      rank = 0;
-    }
-
-    return (label.rank = rank);
   }
 
   _.forEach(g.sources(), dfs);


### PR DESCRIPTION
This issue corresponds to issue: #327.

If I recall correctly, every recursive function can be rewritten in iterative fashion. I took the liberty to rewrite the recursive DFS functions to iterative DFS functions. This also got rid of my `max call stack size` errors. I can now have **dagre** layouts for 10.000 node graphs.

I think there are still recursive DFS functions, but these do not seem to block anything for my use cases.

PS: I was not able to run the `make` file to run tests and styling because I work on Windows.