### PR TITLE
Fixes label typo in `lablepos`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -105,7 +105,7 @@ declare module '@dagrejs/dagre' {
     weight?: number | undefined;
     width?: number | undefined;
     height?: number | undefined;
-    lablepos?: 'l' | 'c' | 'r' | undefined;
+    labelpos?: 'l' | 'c' | 'r' | undefined;
     labeloffest?: number | undefined;
   }
 


### PR DESCRIPTION
The typo is only on the `types.d.ts` files, all the other ones mention `labelpos` correctly.