### PR TITLE
Fix unable to layout compound graph

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -31,7 +31,7 @@ function runLayout(g, time) {
   time("    removeSelfEdges",        () => removeSelfEdges(g));
   time("    acyclic",                () => acyclic.run(g));
   time("    nestingGraph.run",       () => nestingGraph.run(g));
-  time("    rank",                   () => rank(util.asNonCompoundGraph(g)));
+  time("    rank",                   () => rank(g));
   time("    injectEdgeLabelProxies", () => injectEdgeLabelProxies(g));
   time("    removeEmptyRanks",       () => removeEmptyRanks(g));
   time("    nestingGraph.cleanup",   () => nestingGraph.cleanup(g));

--- a/lib/position/index.js
+++ b/lib/position/index.js
@@ -6,8 +6,6 @@ let positionX = require("./bk").positionX;
 module.exports = position;
 
 function position(g) {
-  g = util.asNonCompoundGraph(g);
-
   positionY(g);
   Object.entries(positionX(g)).forEach(([v, x]) => g.node(v).x = x);
 }

--- a/lib/rank/feasible-tree.js
+++ b/lib/rank/feasible-tree.js
@@ -41,7 +41,11 @@ function feasibleTree(g) {
   var edge, delta;
   while (tightTree(t, g) < size) {
     edge = findMinSlackEdge(t, g);
-    delta = t.hasNode(edge.v) ? slack(g, edge) : -slack(g, edge);
+    if (!edge) {
+      delta = Number.POSITIVE_INFINITY;
+    } else {
+      delta = t.hasNode(edge.v) ? slack(g, edge) : -slack(g, edge);
+    }
     shiftRanks(t, g, delta);
   }
 

--- a/lib/rank/feasible-tree.js
+++ b/lib/rank/feasible-tree.js
@@ -41,11 +41,7 @@ function feasibleTree(g) {
   var edge, delta;
   while (tightTree(t, g) < size) {
     edge = findMinSlackEdge(t, g);
-    if (!edge) {
-      delta = Number.POSITIVE_INFINITY;
-    } else {
-      delta = t.hasNode(edge.v) ? slack(g, edge) : -slack(g, edge);
-    }
+    delta = t.hasNode(edge.v) ? slack(g, edge) : -slack(g, edge);
     shiftRanks(t, g, delta);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dagrejs/dagre",
-  "version": "1.0.4",
+  "version": "1.0.5-pre",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dagrejs/dagre",
-      "version": "1.0.4",
+      "version": "1.0.5-pre",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "2.1.13"


### PR DESCRIPTION
related to #236 

It is currently impossible to layout a graph having an edge between a compound element and a simple one.
The error `Cannot set property ‘rank’ of undefined` occurs and breaks the layout process.

It can't be merged as is as it doesn't pass the tests, anyone should feel free to correct it, but it allows to run the layout.