### PR TITLE
Add `Node.rank` to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,7 @@ declare module '@dagrejs/dagre' {
     padding?: number | undefined;
     paddingX?: number | undefined;
     paddingY?: number | undefined;
+    rank?: number | undefined;
     rx?: number | undefined;
     ry?: number | undefined;
     shape?: string | undefined;


### PR DESCRIPTION
Since bcb992f16cae0fed14d4a30371cd5952d802d967, `Node` instances get assigned a `rank` property, but this is not reflected in the type definitions.