### PR TITLE
Add `customOrder` and `disableOptimalOrderHeuristic` - fix #263 merge issues

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -21,12 +21,12 @@ function layout(g, opts) {
   time("layout", () => {
     let layoutGraph =
       time("  buildLayoutGraph", () => buildLayoutGraph(g));
-    time("  runLayout",        () => runLayout(layoutGraph, time));
+    time("  runLayout",        () => runLayout(layoutGraph, time, opts));
     time("  updateInputGraph", () => updateInputGraph(g, layoutGraph));
   });
 }
 
-function runLayout(g, time) {
+function runLayout(g, time, opts) {
   time("    makeSpaceForEdgeLabels", () => makeSpaceForEdgeLabels(g));
   time("    removeSelfEdges",        () => removeSelfEdges(g));
   time("    acyclic",                () => acyclic.run(g));
@@ -41,7 +41,7 @@ function runLayout(g, time) {
   time("    normalize.run",          () => normalize.run(g));
   time("    parentDummyChains",      () => parentDummyChains(g));
   time("    addBorderSegments",      () => addBorderSegments(g));
-  time("    order",                  () => order(g));
+  time("    order",                  () => order(g, opts));
   time("    insertSelfEdges",        () => insertSelfEdges(g));
   time("    adjustCoordinateSystem", () => coordinateSystem.adjust(g));
   time("    position",               () => position(g));


### PR DESCRIPTION
Fixes a merge issue where the changes to layout.js in #263 didn't make it in for some reason.

In the PR there are changes to two files: 

- `lib/layout.js`
- `lib/order/index.js`

This PR was merged and the change assumed to have made it out to a recent release.

However it appears that this isn't the case when you look at the `lib/layout.js` on master: https://github.com/dagrejs/dagre/blob/master/lib/order/index.js

The changes to `lib/order/index.js` made it in however: https://github.com/dagrejs/dagre/blob/master/lib/order/index.js#L41

This PR aims to add in the changes in #263 that should have made it into master when it got merged but somehow didn't.

A good summary of the issue here: https://github.com/OpenFn/lightning/pull/2160#issuecomment-2139807862
