### PR TITLE
graphlib `children()` function should return array of string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module '@dagrejs/dagre' {
       setEdge(params: Edge, value?: string | { [key: string]: any }): Graph<T>;
       setEdge(sourceId: string, targetId: string, value?: string | Label, name?: string): Graph<T>;
 
-      children(v: string): string[];
+      children(parentName: string): string[];
       hasNode(name: string): boolean;
       neighbors(name: string): Array<Node<T>> | undefined;
       node(id: string | Label): Node<T>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module '@dagrejs/dagre' {
       setEdge(params: Edge, value?: string | { [key: string]: any }): Graph<T>;
       setEdge(sourceId: string, targetId: string, value?: string | Label, name?: string): Graph<T>;
 
-      children(parentName: string): string | undefined;
+      children(v: string): string[];
       hasNode(name: string): boolean;
       neighbors(name: string): Array<Node<T>> | undefined;
       node(id: string | Label): Node<T>;


### PR DESCRIPTION
The children() function should align with the one in graphlib, as the children() function in dagre’s graphlib.Graph actually returns an array rather than a string.

Link to the reference in the source code:
https://github.com/dagrejs/graphlib/blob/20f0634d662b03167c0ad2a6fdbdf32db5b6ccb2/index.d.ts#L94