### PR TITLE
Fix typing of graphlib neighbor functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,12 +31,12 @@ declare module '@dagrejs/dagre' {
 
       children(parentName: string): string[];
       hasNode(name: string): boolean;
-      neighbors(name: string): Array<Node<T>> | undefined;
+      neighbors(name: string): string[] | undefined;
       node(id: string | Label): Node<T>;
       nodeCount(): number;
       nodes(): string[];
       parent(childName: string): string | undefined;
-      predecessors(name: string): Array<Node<T>> | undefined;
+      predecessors(name: string): string[] | undefined;
       removeNode(name: string): Graph<T>;
       filterNodes(callback: (nodeId: string) => boolean): Graph<T>;
       setDefaultNodeLabel(callback: string | ((nodeId: string) => string | Label)): Graph<T>;
@@ -44,7 +44,7 @@ declare module '@dagrejs/dagre' {
       setParent(childName: string, parentName: string): void;
       sinks(): Array<Node<T>>;
       sources(): Array<Node<T>>;
-      successors(name: string): Array<Node<T>> | undefined;
+      successors(name: string): string[] | undefined;
     }
 
     namespace json {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dagrejs/dagre",
-  "version": "1.1.4",
+  "version": "1.1.5-pre",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dagrejs/dagre",
-      "version": "1.1.4",
+      "version": "1.1.5-pre",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "2.2.4"


### PR DESCRIPTION
`predecessors` and `successors` both return `Object.keys`, so the return type should be an array of strings, not of `Node<T>`, and `neighbors` is built on top of these