### PR TITLE
Fixed #477: uniqueId producing [object undefined].

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -31,10 +31,10 @@ module.exports = {
  * Adds a dummy node to the graph and return v.
  */
 function addDummyNode(g, type, attrs, name) {
-  let v;
-  do {
+  var v = name;
+  while (g.hasNode(v)) {
     v = uniqueId(name);
-  } while (g.hasNode(v));
+  }
 
   attrs.dummy = type;
   g.setNode(v, attrs);

--- a/lib/util.js
+++ b/lib/util.js
@@ -278,7 +278,7 @@ function notime(name, fn) {
 let idCounter = 0;
 function uniqueId(prefix) {
   var id = ++idCounter;
-  return toString(prefix) + id;
+  return prefix + ("" + id);
 }
 
 function range(start, limit, step = 1) {

--- a/test/unique-id-test.js
+++ b/test/unique-id-test.js
@@ -1,0 +1,28 @@
+var expect = require("./chai").expect;
+var util = require("../lib/util.js");
+
+describe("Given a function to generate unique identifiers", function () {
+  it("uniqueId(name) generates a valid identifier", function () {
+    // This test guards against a bug #477, where the call to toString(prefix) inside
+    // uniqueId() produced [object undefined].
+    var id = util.uniqueId("_root");
+    expect(id).not.to.include('[object undefined]');
+    expect(id).match(/_root\d+/);
+  });
+
+  it("Calling uniqueId(name) multiple times generate distinct values", function () {
+    var first = util.uniqueId("name");
+    var second = util.uniqueId("name");
+    var third = util.uniqueId("name");
+    expect(first).not.equals(second);
+    expect(second).not.equals(third);
+  });
+
+  it("Calling uniqueId(number) with a number creates a valid identifier string", function() {
+    var id = util.uniqueId(99);
+    expect(id).to.be.a('string');
+    expect(id).not.to.be.a('number');
+
+    expect(id).to.match(/99\d+/);
+  });
+});


### PR DESCRIPTION
This PR resolves a tiny bug with the `uniqueId` function converting the `prefix` argument into `[object undefined]`.

## Changes
- `uniqueId` no longer produces invalid identifiers when called with a string value. 
- `addDummyNode` now tries to generate node names starting from the given `name` instead of undefined.