### PR TITLE
improve the performance of the horizontalCompaction function

### DIFF
--- a/lib/position/bk.js
+++ b/lib/position/bk.js
@@ -214,19 +214,24 @@ function horizontalCompaction(g, layering, root, align, reverseSep) {
     borderType = reverseSep ? "borderLeft" : "borderRight";
 
   function iterate(setXsFunc, nextNodesFunc) {
-    let stack = blockG.nodes();
-    let elem = stack.pop();
-    let visited = {};
-    while (elem) {
+    const stack = blockG.nodes().slice(); // Create a copy of the node list.
+    const visited = {};
+    while (true) {
+      const elem = stack.pop();
+      if (!elem) {
+        break;
+      }
       if (visited[elem]) {
         setXsFunc(elem);
       } else {
         visited[elem] = true;
+        // Put the element back into the stack, so that we can process it
+        // again after all of the `nextNodesFunc` items are processed.
         stack.push(elem);
-        stack = stack.concat(nextNodesFunc(elem));
+        for (const nextElem of nextNodesFunc(elem)) {
+          stack.push(nextElem);
+        }
       }
-
-      elem = stack.pop();
     }
   }
 


### PR DESCRIPTION
The function `arr1.concat(arr2)` produces a new array, so it runs in time O(arr1.length + arr2.length). This means that if the stack gets deep, iterate ends up taking quadratic time to copy all nodes in the stack every iteration.

Instead, we call `.push(x)` once for each item in arr2, which runs in time O(arr2.length).

Since `g.nodes()` is a reference to the internal node list of the graph, modifying it in-place seems undesirable. Call `.slice()` once to get a copy of this list, and then subsequently modify it in place with .push()/.pop().

This change reduced the time to run the position function from 4056ms down to 1928ms on a particular clustered graph with 1712 nodes and 1529 edges.