### PR TITLE
fix: Add missing constraints to layout configuration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,7 @@ export interface EdgeConfig {
 export interface LayoutConfig {
   customOrder?: (graph: graphlib.Graph, order: (graph: graphlib.Graph, opts: configUnion) => void) => void;
   disableOptimalOrderHeuristic?: boolean;
+  constraints?: Array<{ left: string; right: string }>
 }
 
 type configUnion = GraphLabel & NodeConfig & EdgeConfig & LayoutConfig;


### PR DESCRIPTION
This pull request adds `constraints` to the layout configuration, an attribute that is currently missing. This follows from this [PR](https://github.com/dagrejs/dagre/pull/302) to add ability to define order constraints within rank.


