### PR TITLE
feat: add interactive demo on github pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy website
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            website/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm ci --prefix website
+
+      - name: Build website website
+        run: npm run build --prefix website
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,5 @@
+build/
+node_modules/
+tmp/
+coverage/
+dist

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Dagre Demo</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,2529 @@
+{
+    "name": "@dagrejs/dagre-demo",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@dagrejs/dagre-demo",
+            "version": "0.0.0",
+            "dependencies": {
+                "d3": "^7.9.0",
+                "lucide-react": "^0.468.0",
+                "react": "^18.3.1",
+                "react-dom": "^18.3.1"
+            },
+            "devDependencies": {
+                "@types/d3": "^7.4.3",
+                "@types/react": "^18.3.28",
+                "@types/react-dom": "^18.3.7",
+                "@vitejs/plugin-react": "^4.7.0",
+                "typescript": "^5.9.3",
+                "vite": "^5.4.21"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helpers": "^7.28.6",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.28.6",
+                "@babel/helper-validator-option": "^7.27.1",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.0"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-jsx-self": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+            "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-jsx-source": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+            "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.27",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@types/babel__core": {
+            "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.2"
+            }
+        },
+        "node_modules/@types/d3": {
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+            "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-array": "*",
+                "@types/d3-axis": "*",
+                "@types/d3-brush": "*",
+                "@types/d3-chord": "*",
+                "@types/d3-color": "*",
+                "@types/d3-contour": "*",
+                "@types/d3-delaunay": "*",
+                "@types/d3-dispatch": "*",
+                "@types/d3-drag": "*",
+                "@types/d3-dsv": "*",
+                "@types/d3-ease": "*",
+                "@types/d3-fetch": "*",
+                "@types/d3-force": "*",
+                "@types/d3-format": "*",
+                "@types/d3-geo": "*",
+                "@types/d3-hierarchy": "*",
+                "@types/d3-interpolate": "*",
+                "@types/d3-path": "*",
+                "@types/d3-polygon": "*",
+                "@types/d3-quadtree": "*",
+                "@types/d3-random": "*",
+                "@types/d3-scale": "*",
+                "@types/d3-scale-chromatic": "*",
+                "@types/d3-selection": "*",
+                "@types/d3-shape": "*",
+                "@types/d3-time": "*",
+                "@types/d3-time-format": "*",
+                "@types/d3-timer": "*",
+                "@types/d3-transition": "*",
+                "@types/d3-zoom": "*"
+            }
+        },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-axis": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+            "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-brush": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+            "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-chord": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+            "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-contour": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+            "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-array": "*",
+                "@types/geojson": "*"
+            }
+        },
+        "node_modules/@types/d3-delaunay": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+            "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-dispatch": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+            "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-drag": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+            "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-dsv": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+            "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-fetch": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+            "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-dsv": "*"
+            }
+        },
+        "node_modules/@types/d3-force": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+            "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-format": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+            "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-geo": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+            "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/geojson": "*"
+            }
+        },
+        "node_modules/@types/d3-hierarchy": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+            "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-polygon": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+            "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-quadtree": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+            "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-random": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+            "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-scale-chromatic": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+            "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-selection": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+            "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-time-format": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+            "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-transition": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+            "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-zoom": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+            "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-interpolate": "*",
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/geojson": {
+            "version": "7946.0.16",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+            "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "18.3.28",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+            "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "18.3.7",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^18.0.0"
+            }
+        },
+        "node_modules/@vitejs/plugin-react": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+            "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.28.0",
+                "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+                "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+                "@rolldown/pluginutils": "1.0.0-beta.27",
+                "@types/babel__core": "^7.20.5",
+                "react-refresh": "^0.17.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+            }
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.29",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+            "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.28.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.10.12",
+                "caniuse-lite": "^1.0.30001782",
+                "electron-to-chromium": "^1.5.328",
+                "node-releases": "^2.0.36",
+                "update-browserslist-db": "^1.2.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001792",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/d3": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+            "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "3",
+                "d3-axis": "3",
+                "d3-brush": "3",
+                "d3-chord": "3",
+                "d3-color": "3",
+                "d3-contour": "4",
+                "d3-delaunay": "6",
+                "d3-dispatch": "3",
+                "d3-drag": "3",
+                "d3-dsv": "3",
+                "d3-ease": "3",
+                "d3-fetch": "3",
+                "d3-force": "3",
+                "d3-format": "3",
+                "d3-geo": "3",
+                "d3-hierarchy": "3",
+                "d3-interpolate": "3",
+                "d3-path": "3",
+                "d3-polygon": "3",
+                "d3-quadtree": "3",
+                "d3-random": "3",
+                "d3-scale": "4",
+                "d3-scale-chromatic": "3",
+                "d3-selection": "3",
+                "d3-shape": "3",
+                "d3-time": "3",
+                "d3-time-format": "4",
+                "d3-timer": "3",
+                "d3-transition": "3",
+                "d3-zoom": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-axis": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-brush": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "3",
+                "d3-transition": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-chord": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-contour": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-delaunay": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+            "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+            "license": "ISC",
+            "dependencies": {
+                "delaunator": "5"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dispatch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-drag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dsv": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+            "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+            "license": "ISC",
+            "dependencies": {
+                "commander": "7",
+                "iconv-lite": "0.6",
+                "rw": "1"
+            },
+            "bin": {
+                "csv2json": "bin/dsv2json.js",
+                "csv2tsv": "bin/dsv2dsv.js",
+                "dsv2dsv": "bin/dsv2dsv.js",
+                "dsv2json": "bin/dsv2json.js",
+                "json2csv": "bin/json2dsv.js",
+                "json2dsv": "bin/json2dsv.js",
+                "json2tsv": "bin/json2dsv.js",
+                "tsv2csv": "bin/dsv2dsv.js",
+                "tsv2json": "bin/dsv2json.js"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-fetch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dsv": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-force": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+            "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-quadtree": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-geo": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+            "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.5.0 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-hierarchy": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+            "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-polygon": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-quadtree": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+            "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-random": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale-chromatic": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+            "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-interpolate": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-selection": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-transition": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "d3-selection": "2 - 3"
+            }
+        },
+        "node_modules/d3-zoom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/delaunator": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+            "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+            "license": "ISC",
+            "dependencies": {
+                "robust-predicates": "^3.0.2"
+            }
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.354",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.354.tgz",
+            "integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/esbuild": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/lucide-react": {
+            "version": "0.468.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
+            "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.44",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/postcss": {
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/react": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.2"
+            },
+            "peerDependencies": {
+                "react": "^18.3.1"
+            }
+        },
+        "node_modules/react-refresh": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+            "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/robust-predicates": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+            "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+            "license": "Unlicense"
+        },
+        "node_modules/rollup": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.60.3",
+                "@rollup/rollup-android-arm64": "4.60.3",
+                "@rollup/rollup-darwin-arm64": "4.60.3",
+                "@rollup/rollup-darwin-x64": "4.60.3",
+                "@rollup/rollup-freebsd-arm64": "4.60.3",
+                "@rollup/rollup-freebsd-x64": "4.60.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+                "@rollup/rollup-linux-arm64-musl": "4.60.3",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+                "@rollup/rollup-linux-loong64-musl": "4.60.3",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-musl": "4.60.3",
+                "@rollup/rollup-openbsd-x64": "4.60.3",
+                "@rollup/rollup-openharmony-arm64": "4.60.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+                "@rollup/rollup-win32-x64-gnu": "4.60.3",
+                "@rollup/rollup-win32-x64-msvc": "4.60.3",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rw": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+            "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/vite": {
+            "version": "5.4.21",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
+            "license": "ISC"
+        }
+    }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@dagrejs/dagre-demo",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "vite --host 127.0.0.1",
+        "build": "tsc -p tsconfig.json && vite build",
+        "preview": "vite preview --host 127.0.0.1"
+    },
+    "dependencies": {
+        "d3": "^7.9.0",
+        "lucide-react": "^0.468.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+    },
+    "devDependencies": {
+        "@types/d3": "^7.4.3",
+        "@types/react": "^18.3.28",
+        "@types/react-dom": "^18.3.7",
+        "@vitejs/plugin-react": "^4.7.0",
+        "typescript": "^5.9.3",
+        "vite": "^5.4.21"
+    }
+}

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,0 +1,192 @@
+import {useEffect, useMemo, useState} from 'react';
+import {Compass, Github, Menu, MoveHorizontal, Rocket, Scaling, SlidersHorizontal, Table2, Tags, X} from 'lucide-react';
+import type {LucideIcon} from 'lucide-react';
+import type {ReactElement} from 'react';
+import {InteractiveDemo} from './components/InteractiveDemo';
+import {pages} from './content/pages';
+import type {AttributeDefinition} from './content/types';
+
+const navIcons: Record<string, LucideIcon> = {
+    'getting-started': Rocket,
+    attributes: Table2,
+    'layout-direction': Compass,
+    spacing: SlidersHorizontal,
+    'node-sizes': Scaling,
+    'edge-labels': Tags,
+};
+
+function pageIdFromHash(): string | undefined {
+    const hashId = window.location.hash.replace(/^#/, '');
+    return pages.find((page) => page.id === hashId || page.sections.some((section) => section.id === hashId))?.id;
+}
+
+function AttributeTable({attributes}: {attributes: AttributeDefinition[]}): ReactElement {
+    return (
+        <div className="attribute-table-wrap">
+            <table className="attribute-table">
+                <thead>
+                    <tr>
+                        <th>Target</th>
+                        <th>Name</th>
+                        <th>Default</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {attributes.map((attribute) => (
+                        <tr key={`${attribute.target}-${attribute.name}`}>
+                            <td>{attribute.target}</td>
+                            <td>
+                                <code>{attribute.name}</code>
+                            </td>
+                            <td>
+                                <code>{attribute.defaultValue}</code>
+                            </td>
+                            <td>{attribute.description}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+export function App(): ReactElement {
+    const firstPage = pages[0];
+
+    if (!firstPage) {
+        throw new Error('No demo pages configured');
+    }
+
+    const fallbackPageId = firstPage.id;
+    const [activePageId, setActivePageId] = useState(() => pageIdFromHash() ?? fallbackPageId);
+    const [isNavOpen, setIsNavOpen] = useState(false);
+    const activePage = useMemo(
+        () => pages.find((page) => page.id === activePageId) ?? firstPage,
+        [activePageId],
+    );
+
+    useEffect(() => {
+        function syncPageFromHash(): void {
+            const hashPageId = pageIdFromHash();
+            if (hashPageId) {
+                setActivePageId(hashPageId);
+            }
+        }
+
+        window.addEventListener('hashchange', syncPageFromHash);
+        return () => window.removeEventListener('hashchange', syncPageFromHash);
+    }, [fallbackPageId]);
+
+    useEffect(() => {
+        const hashId = window.location.hash.replace(/^#/, '');
+        const target = hashId ? document.getElementById(hashId) : null;
+
+        if (target) {
+            requestAnimationFrame(() => target.scrollIntoView());
+        }
+    }, [activePageId]);
+
+    return (
+        <div className="app-shell">
+            <header className="topbar">
+                <button className="icon-button nav-toggle" type="button" onClick={() => setIsNavOpen(true)} aria-label="Open navigation">
+                    <Menu size={20} />
+                </button>
+                <a className="topbar-link" href="https://github.com/dagrejs/dagre" target="_blank" rel="noreferrer">
+                    <Github size={18} />
+                    GitHub
+                </a>
+                <div className="version-pill">Dagre v3.0.1-pre</div>
+            </header>
+
+            <div className="docs-frame">
+                <nav className={`sidebar ${isNavOpen ? 'is-open' : ''}`} aria-label="Demo pages" tabIndex={-1}>
+                    <div className="sidebar-gradient" />
+                    <div className="sidebar-container">
+                        <div className="sidebar-top">
+                            <a className="sidebar-wordmark" href="#getting-started" onClick={() => setActivePageId('getting-started')}>
+                                Dagre
+                            </a>
+                            <button className="icon-button mobile-only" type="button" onClick={() => setIsNavOpen(false)} aria-label="Close navigation">
+                                <X size={18} />
+                            </button>
+                        </div>
+                        <ul className="nav-list">
+                            {pages.map((page) => {
+                                const Icon = navIcons[page.id] ?? MoveHorizontal;
+
+                                return (
+                                    <li key={page.id}>
+                                        <a
+                                            className={page.id === activePage.id ? 'active' : ''}
+                                            href={`#${page.id}`}
+                                            aria-current={page.id === activePage.id ? 'page' : undefined}
+                                            onClick={() => {
+                                                setActivePageId(page.id);
+                                                setIsNavOpen(false);
+                                            }}
+                                        >
+                                            <Icon size={24} strokeWidth={1.7} />
+                                            <span>{page.navTitle}</span>
+                                        </a>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </div>
+                </nav>
+
+                {isNavOpen && (
+                    <button className="nav-scrim" type="button" onClick={() => setIsNavOpen(false)} aria-label="Close navigation">
+                        <span />
+                    </button>
+                )}
+
+                <main className="content">
+                    <section className="page-card" id={activePage.id}>
+                        <div className="page-card-icon">D</div>
+                        <div>
+                            <p className="eyebrow">{activePage.eyebrow}</p>
+                            <h1>{activePage.title}</h1>
+                            <p className="lead">{activePage.description}</p>
+                        </div>
+                    </section>
+
+                    {activePage.sections.map((section) => (
+                        <section className="doc-section" id={section.id} key={section.id}>
+                            <div className="section-copy">
+                                <h2>{section.title}</h2>
+                                {section.body.map((paragraph) => (
+                                    <p key={paragraph}>{paragraph}</p>
+                                ))}
+                            </div>
+                            {section.demo && <InteractiveDemo demo={section.demo} />}
+                            {section.attributes && <AttributeTable attributes={section.attributes} />}
+                        </section>
+                    ))}
+
+                    <footer className="site-footer">
+                        <p>© 2026 • MIT License</p>
+                        <p>
+                            Inspired by{' '}
+                            <a href="https://floating-ui.com/" target="_blank" rel="noreferrer">
+                                Floating UI
+                            </a>{' '}
+                            design.
+                        </p>
+                    </footer>
+                </main>
+
+                <aside className="toc">
+                    <span>On this page</span>
+                    {activePage.sections.map((section) => (
+                        <a href={`#${section.id}`} key={section.id}>
+                            {section.title}
+                        </a>
+                    ))}
+                </aside>
+            </div>
+        </div>
+    );
+}

--- a/website/src/components/CodeBlock.tsx
+++ b/website/src/components/CodeBlock.tsx
@@ -1,0 +1,13 @@
+import type {ReactElement} from 'react';
+
+type CodeBlockProps = {
+    code: string;
+};
+
+export function CodeBlock({code}: CodeBlockProps): ReactElement {
+    return (
+        <pre className="code-block">
+            <code>{code}</code>
+        </pre>
+    );
+}

--- a/website/src/components/D3DagreDemo.tsx
+++ b/website/src/components/D3DagreDemo.tsx
@@ -1,0 +1,149 @@
+import {useEffect, useRef} from 'react';
+import * as d3 from 'd3';
+import * as dagre from '@dagrejs/dagre';
+import type {EdgeLabel, GraphLabel, NodeLabel} from '@dagrejs/dagre';
+import type {Edge, Graph} from '@dagrejs/graphlib';
+import type {ReactElement} from 'react';
+
+type D3DagreDemoProps = {
+    graph: Graph<GraphLabel, NodeLabel, EdgeLabel>;
+};
+
+type RenderNode = NodeLabel & {
+    id: string;
+    label: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+
+type RenderEdge = EdgeLabel & {
+    id: string;
+    edge: Edge;
+};
+
+export function D3DagreDemo({graph}: D3DagreDemoProps): ReactElement {
+    const svgRef = useRef<SVGSVGElement | null>(null);
+
+    useEffect(() => {
+        if (!svgRef.current) {
+            return;
+        }
+
+        dagre.layout(graph);
+
+        const graphLabel = graph.graph();
+        const width = Math.max(520, Number(graphLabel.width ?? 520) + 48);
+        const height = Math.max(300, Number(graphLabel.height ?? 300) + 48);
+        const nodes = graph.nodes().map((id): RenderNode => {
+            const node = graph.node(id);
+
+            return {
+                ...node,
+                id,
+                label: typeof node.label === 'string' ? node.label : id,
+                x: Number(node.x ?? 0),
+                y: Number(node.y ?? 0),
+                width: Number(node.width),
+                height: Number(node.height),
+            };
+        });
+        const edges = graph.edges().map((edge): RenderEdge => ({
+            ...graph.edge(edge),
+            id: `${edge.v}-${edge.w}-${edge.name ?? 'edge'}`,
+            edge,
+        }));
+
+        const svg = d3.select(svgRef.current);
+        svg.selectAll('*').remove();
+        svg.attr('viewBox', `0 0 ${width} ${height}`);
+
+        const root = svg.append('g').attr('class', 'graph-root');
+        const content = root
+            .append('g')
+            .attr('transform', 'translate(24, 24)');
+
+        svg.call(
+            d3.zoom<SVGSVGElement, unknown>()
+                .scaleExtent([0.35, 2])
+                .on('zoom', (event) => {
+                    root.attr('transform', event.transform.toString());
+                }),
+        );
+
+        const line = d3.line<{x: number; y: number}>()
+            .x((point) => point.x)
+            .y((point) => point.y)
+            .curve(d3.curveBasis);
+
+        content
+            .append('g')
+            .attr('class', 'edges')
+            .selectAll('path')
+            .data(edges)
+            .join('path')
+            .attr('class', (edge) => `edge-path ${typeof edge.class === 'string' ? edge.class : ''}`)
+            .style('stroke-width', (edge) => {
+                const weight = Number(edge.weight ?? 1);
+                return typeof edge.class === 'string' && edge.class.includes('focus')
+                    ? 1.8 + weight * 0.28
+                    : 1.8;
+            })
+            .attr('d', (edge) => line(edge.points ?? []) ?? '');
+
+        const edgeLabelGroups = content
+            .append('g')
+            .attr('class', 'edge-labels')
+            .selectAll('g')
+            .data(edges.filter((edge) => typeof edge.label === 'string'))
+            .join('g')
+            .attr('class', (edge) => `edge-label ${typeof edge.class === 'string' ? edge.class : ''}`)
+            .attr('transform', (edge) => `translate(${Number(edge.x ?? 0)}, ${Number(edge.y ?? 0)})`);
+
+        edgeLabelGroups
+            .append('rect')
+            .attr('x', (edge) => -Number(edge.width ?? 0) / 2)
+            .attr('y', (edge) => -Number(edge.height ?? 0) / 2)
+            .attr('width', (edge) => Number(edge.width ?? 0))
+            .attr('height', (edge) => Number(edge.height ?? 0))
+            .attr('rx', 5)
+            .attr('ry', 5);
+
+        edgeLabelGroups
+            .append('text')
+            .attr('text-anchor', 'middle')
+            .attr('dominant-baseline', 'middle')
+            .text((edge) => String(edge.label));
+
+        const nodeGroups = content
+            .append('g')
+            .attr('class', 'nodes')
+            .selectAll('g')
+            .data(nodes)
+            .join('g')
+            .attr('class', (node) => `node ${typeof node.class === 'string' ? node.class : ''}`)
+            .attr('transform', (node) => `translate(${node.x - node.width / 2}, ${node.y - node.height / 2})`);
+
+        nodeGroups
+            .append('rect')
+            .attr('width', (node) => node.width)
+            .attr('height', (node) => node.height)
+            .attr('rx', 7)
+            .attr('ry', 7);
+
+        nodeGroups
+            .append('text')
+            .attr('x', (node) => node.width / 2)
+            .attr('y', (node) => node.height / 2)
+            .attr('text-anchor', 'middle')
+            .attr('dominant-baseline', 'middle')
+            .text((node) => node.label);
+    }, [graph]);
+
+    return (
+        <div className="graph-stage">
+            <svg ref={svgRef} role="img" aria-label="Dagre graph rendered with D3" />
+        </div>
+    );
+}

--- a/website/src/components/DemoControls.tsx
+++ b/website/src/components/DemoControls.tsx
@@ -1,0 +1,84 @@
+import type {Control, DemoDefinition, DemoSettings} from '../content/types';
+import type {ReactElement} from 'react';
+
+type DemoControlsProps = {
+    demo: DemoDefinition;
+    settings: DemoSettings;
+    onChange: (settings: DemoSettings) => void;
+};
+
+export function DemoControls({demo, settings, onChange}: DemoControlsProps): ReactElement | null {
+    if (demo.controls.length === 0) {
+        return null;
+    }
+
+    function updateSetting(key: keyof DemoSettings, value: string | number): void {
+        const currentValue = settings[key];
+        onChange({
+            ...settings,
+            [key]: typeof currentValue === 'number' ? Number(value) : value,
+        });
+    }
+
+    return (
+        <div className="demo-controls">
+            {demo.controls.map((control) => (
+                <ControlField
+                    control={control}
+                    key={`${demo.id}-${control.key}`}
+                    settings={settings}
+                    onChange={updateSetting}
+                />
+            ))}
+        </div>
+    );
+}
+
+type ControlFieldProps = {
+    control: Control;
+    settings: DemoSettings;
+    onChange: (key: keyof DemoSettings, value: string | number) => void;
+};
+
+function ControlField({control, settings, onChange}: ControlFieldProps): ReactElement {
+    const value = settings[control.key];
+
+    if (control.type === 'range') {
+        const numericValue = typeof value === 'number' ? value : control.min;
+
+        return (
+            <label className="range-control">
+                <span>
+                    {control.label}
+                    <strong>{numericValue}</strong>
+                </span>
+                <input
+                    type="range"
+                    min={control.min}
+                    max={control.max}
+                    step={control.step}
+                    value={numericValue}
+                    onChange={(event) => onChange(control.key, Number(event.target.value))}
+                />
+            </label>
+        );
+    }
+
+    return (
+        <div className="segmented-control" role="group" aria-label={control.label}>
+            <span>{control.label}</span>
+            <div>
+                {control.options.map((option) => (
+                    <button
+                        className={value === option.value ? 'selected' : ''}
+                        key={option.value}
+                        type="button"
+                        onClick={() => onChange(control.key, option.value)}
+                    >
+                        {option.label}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/website/src/components/InteractiveDemo.tsx
+++ b/website/src/components/InteractiveDemo.tsx
@@ -1,0 +1,30 @@
+import {useMemo, useState} from 'react';
+import {CodeBlock} from './CodeBlock';
+import {D3DagreDemo} from './D3DagreDemo';
+import {DemoControls} from './DemoControls';
+import type {DemoDefinition} from '../content/types';
+import type {ReactElement} from 'react';
+
+type InteractiveDemoProps = {
+    demo: DemoDefinition;
+};
+
+export function InteractiveDemo({demo}: InteractiveDemoProps): ReactElement {
+    const [settings, setSettings] = useState(demo.initialSettings);
+    const graph = useMemo(() => demo.buildGraph(settings), [demo, settings]);
+    const code = useMemo(() => demo.code(settings), [demo, settings]);
+
+    return (
+        <div className="demo-block">
+            <div className="demo-heading">
+                <div>
+                    <h3>{demo.title}</h3>
+                    <p>{demo.caption}</p>
+                </div>
+                <DemoControls demo={demo} settings={settings} onChange={setSettings} />
+            </div>
+            <D3DagreDemo graph={graph} />
+            <CodeBlock code={code} />
+        </div>
+    );
+}

--- a/website/src/content/graphBuilders.ts
+++ b/website/src/content/graphBuilders.ts
@@ -1,0 +1,301 @@
+import * as dagre from '@dagrejs/dagre';
+import type {EdgeLabel, GraphLabel, NodeLabel} from '@dagrejs/dagre';
+import type {Graph} from '@dagrejs/graphlib';
+import type {DemoSettings, LabelPosition, RankDirection} from './types';
+
+type DagreGraph = Graph<GraphLabel, NodeLabel, EdgeLabel>;
+
+type NodeInput = {
+    id: string;
+    label: string;
+    width: number;
+    height: number;
+    className?: string;
+};
+
+type EdgeInput = {
+    v: string;
+    w: string;
+    label?: string;
+    minlen?: number;
+    weight?: number;
+    labelpos?: LabelPosition;
+    labeloffset?: number;
+    className?: string;
+    width?: number;
+    height?: number;
+};
+
+function createGraph(settings: DemoSettings): DagreGraph {
+    const graph = new dagre.graphlib.Graph<GraphLabel, NodeLabel, EdgeLabel>({
+        multigraph: true,
+        compound: true,
+    });
+
+    const graphLabel: GraphLabel = {
+        rankdir: settings.rankdir ?? 'TB',
+        align: settings.align,
+        nodesep: settings.nodesep ?? 50,
+        ranksep: settings.ranksep ?? 70,
+        edgesep: settings.edgesep ?? 20,
+        marginx: settings.marginx ?? 24,
+        marginy: settings.marginy ?? 24,
+        ranker: settings.ranker,
+        acyclicer: settings.acyclicer === 'greedy' ? 'greedy' : undefined,
+    };
+
+    graph.setGraph(graphLabel);
+    graph.setDefaultEdgeLabel(() => ({}));
+
+    return graph;
+}
+
+function addNodes(graph: DagreGraph, nodes: NodeInput[]): void {
+    nodes.forEach((node) => {
+        graph.setNode(node.id, {
+            label: node.label,
+            width: node.width,
+            height: node.height,
+            class: node.className,
+        });
+    });
+}
+
+function addEdges(graph: DagreGraph, edges: EdgeInput[]): void {
+    edges.forEach((edge) => {
+        graph.setEdge(edge.v, edge.w, {
+            label: edge.label,
+            width: edge.width ?? (edge.label ? Math.max(48, edge.label.length * 7) : 0),
+            height: edge.height ?? (edge.label ? 20 : 0),
+            minlen: edge.minlen,
+            weight: edge.weight,
+            labelpos: edge.labelpos,
+            labeloffset: edge.labeloffset,
+            class: edge.className,
+        });
+    });
+}
+
+export function buildGettingStartedGraph(settings: DemoSettings): DagreGraph {
+    const graph = createGraph(settings);
+
+    addNodes(graph, [
+        {id: 'configure', label: 'Configure', width: 116, height: 44, className: 'accent'},
+        {id: 'build', label: 'Build graph', width: 118, height: 44},
+        {id: 'layout', label: 'Run layout', width: 112, height: 44},
+        {id: 'render', label: 'Render SVG', width: 112, height: 44, className: 'success'},
+    ]);
+    addEdges(graph, [
+        {v: 'configure', w: 'build'},
+        {v: 'build', w: 'layout'},
+        {v: 'layout', w: 'render'},
+    ]);
+
+    return graph;
+}
+
+export function buildWorkflowGraph(settings: DemoSettings): DagreGraph {
+    const graph = createGraph(settings);
+
+    addNodes(graph, [
+        {id: 'request', label: 'Request', width: 100, height: 44, className: 'accent'},
+        {id: 'auth', label: 'Authorize', width: 104, height: 44},
+        {id: 'validate', label: 'Validate data', width: 122, height: 44},
+        {id: 'quote', label: 'Quote', width: 88, height: 44},
+        {id: 'approval', label: 'Approval', width: 104, height: 44},
+        {id: 'fulfill', label: 'Fulfill', width: 96, height: 44},
+        {id: 'notify', label: 'Notify', width: 92, height: 44, className: 'success'},
+        {id: 'reject', label: 'Reject', width: 92, height: 44, className: 'warning'},
+    ]);
+    addEdges(graph, [
+        {v: 'request', w: 'auth'},
+        {v: 'auth', w: 'validate'},
+        {v: 'validate', w: 'quote'},
+        {v: 'quote', w: 'approval'},
+        {v: 'approval', w: 'fulfill', label: 'approved'},
+        {v: 'fulfill', w: 'notify'},
+        {v: 'approval', w: 'reject', label: 'denied'},
+    ]);
+
+    return graph;
+}
+
+export function buildSpacingGraph(settings: DemoSettings): DagreGraph {
+    const graph = createGraph(settings);
+
+    addNodes(graph, [
+        {id: 'a', label: 'A', width: 64, height: 42},
+        {id: 'b', label: 'B', width: 64, height: 42},
+        {id: 'c', label: 'C', width: 64, height: 42},
+        {id: 'd', label: 'D', width: 64, height: 42},
+        {id: 'e', label: 'E', width: 64, height: 42},
+        {id: 'f', label: 'F', width: 64, height: 42},
+    ]);
+    addEdges(graph, [
+        {v: 'a', w: 'b'},
+        {v: 'a', w: 'c'},
+        {v: 'b', w: 'd'},
+        {v: 'c', w: 'd'},
+        {v: 'c', w: 'e'},
+        {v: 'd', w: 'f'},
+        {v: 'e', w: 'f'},
+    ]);
+
+    return graph;
+}
+
+export function buildNodeSizesGraph(settings: DemoSettings): DagreGraph {
+    const graph = createGraph(settings);
+    const wide = settings.nodeSize === 'wide';
+    const mixed = settings.nodeSize !== 'compact';
+
+    addNodes(graph, [
+        {id: 'source', label: 'Source', width: 88, height: 42, className: 'accent'},
+        {id: 'parser', label: mixed ? 'Parse and normalize' : 'Parse', width: mixed ? 164 : 86, height: 44},
+        {id: 'rules', label: wide ? 'Apply business validation rules' : 'Rules', width: wide ? 238 : 92, height: 52},
+        {id: 'store', label: 'Store', width: 86, height: mixed ? 62 : 42},
+        {id: 'report', label: mixed ? 'Generate report' : 'Report', width: mixed ? 148 : 92, height: 44, className: 'success'},
+    ]);
+    addEdges(graph, [
+        {v: 'source', w: 'parser'},
+        {v: 'parser', w: 'rules'},
+        {v: 'rules', w: 'store'},
+        {v: 'rules', w: 'report'},
+        {v: 'store', w: 'report'},
+    ]);
+
+    return graph;
+}
+
+export function buildEdgeLabelsGraph(settings: DemoSettings): DagreGraph {
+    const graph = createGraph(settings);
+
+    addNodes(graph, [
+        {id: 'draft', label: 'Draft', width: 86, height: 42},
+        {id: 'review', label: 'Review', width: 94, height: 42, className: 'accent'},
+        {id: 'changes', label: 'Changes', width: 104, height: 42, className: 'warning'},
+        {id: 'publish', label: 'Publish', width: 102, height: 42, className: 'success'},
+    ]);
+    addEdges(graph, [
+        {v: 'draft', w: 'review', label: 'submit'},
+        {v: 'review', w: 'changes', label: 'needs work'},
+        {v: 'changes', w: 'review', label: 'resubmit', minlen: 2},
+        {v: 'review', w: 'publish', label: 'approved'},
+    ]);
+
+    return graph;
+}
+
+export function buildEdgeAttributesGraph(settings: DemoSettings): DagreGraph {
+    const graph = createGraph({
+        ...settings,
+        nodesep: Math.max(settings.nodesep ?? 54, settings.labelWidth ?? 72),
+    });
+    const labelWidth = settings.labelWidth ?? 72;
+    const weight = settings.weight ?? 1;
+    const competingWeight = Math.max(1, 26 - weight);
+
+    addNodes(graph, [
+        {id: 'source', label: 'Source', width: 90, height: 42},
+        {id: 'main', label: 'High weight path', width: 138, height: 44, className: 'accent'},
+        {id: 'alternate', label: 'Alternate path', width: 128, height: 44, className: 'warning'},
+        {id: 'sink', label: 'Sink', width: 82, height: 42, className: 'success'},
+        {id: 'audit', label: 'Audit', width: 84, height: 42},
+    ]);
+    addEdges(graph, [
+        {
+            v: 'source',
+            w: 'main',
+            label: 'controlled',
+            minlen: settings.minlen,
+            weight,
+            labelpos: settings.labelpos,
+            labeloffset: settings.labeloffset,
+            className: 'focus',
+            width: labelWidth,
+            height: 24,
+        },
+        {
+            v: 'main',
+            w: 'sink',
+            label: 'finish',
+            minlen: settings.minlen,
+            weight,
+            labelpos: settings.labelpos,
+            labeloffset: settings.labeloffset,
+            className: 'focus',
+            width: labelWidth,
+            height: 24,
+        },
+        {v: 'source', w: 'alternate', label: 'other', weight: competingWeight},
+        {v: 'alternate', w: 'sink', label: 'merge', weight: competingWeight},
+        {v: 'main', w: 'audit', label: 'side check', minlen: 2, weight: 1},
+        {v: 'audit', w: 'sink', label: 'report', weight: 1},
+    ]);
+
+    return graph;
+}
+
+export function buildAttributeGraph(settings: DemoSettings): DagreGraph {
+    const graph = createGraph({
+        rankdir: settings.rankdir ?? 'LR',
+        align: settings.align,
+        nodesep: settings.nodesep ?? 48,
+        ranksep: settings.ranksep ?? 76,
+        edgesep: settings.edgesep ?? 18,
+        marginx: settings.marginx ?? 24,
+        marginy: settings.marginy ?? 24,
+        ranker: settings.ranker ?? 'network-simplex',
+        acyclicer: settings.acyclicer,
+    });
+
+    addNodes(graph, [
+        {id: 'start', label: 'Start', width: 82, height: 42, className: 'accent'},
+        {id: 'split', label: 'Split', width: 82, height: 42},
+        {id: 'fast', label: 'Fast path', width: 104, height: 42},
+        {id: 'review', label: 'Review', width: 100, height: 42, className: 'warning'},
+        {id: 'join', label: 'Join', width: 78, height: 42},
+        {id: 'finish', label: 'Finish', width: 88, height: 42, className: 'success'},
+    ]);
+    addEdges(graph, [
+        {v: 'start', w: 'split'},
+        {v: 'split', w: 'fast', weight: 2},
+        {v: 'split', w: 'review'},
+        {v: 'review', w: 'split'},
+        {v: 'fast', w: 'join'},
+        {v: 'review', w: 'join', minlen: 2},
+        {v: 'join', w: 'finish'},
+    ]);
+
+    return graph;
+}
+
+export function graphOptionsSnippet(settings: DemoSettings): string {
+    const rankdir = settings.rankdir ?? 'TB';
+    const nodesep = settings.nodesep ?? 50;
+    const ranksep = settings.ranksep ?? 70;
+    const edgesep = settings.edgesep ?? 20;
+    const extraOptions = [
+        settings.align ? `  align: "${settings.align}",` : undefined,
+        settings.marginx !== undefined ? `  marginx: ${settings.marginx},` : undefined,
+        settings.marginy !== undefined ? `  marginy: ${settings.marginy},` : undefined,
+        settings.ranker ? `  ranker: "${settings.ranker}",` : undefined,
+        settings.acyclicer === 'greedy' ? '  acyclicer: "greedy",' : undefined,
+    ].filter(Boolean);
+
+    return `g.setGraph({
+  rankdir: "${rankdir}",
+  nodesep: ${nodesep},
+  ranksep: ${ranksep},
+  edgesep: ${edgesep},${extraOptions.length ? `\n${extraOptions.join('\n')}` : ''}
+});`;
+}
+
+export function rankdirOptions(): Array<{label: string; value: RankDirection}> {
+    return [
+        {label: 'TB', value: 'TB'},
+        {label: 'BT', value: 'BT'},
+        {label: 'LR', value: 'LR'},
+        {label: 'RL', value: 'RL'},
+    ];
+}

--- a/website/src/content/pages.ts
+++ b/website/src/content/pages.ts
@@ -1,0 +1,542 @@
+import {
+    buildAttributeGraph,
+    buildEdgeAttributesGraph,
+    buildEdgeLabelsGraph,
+    buildGettingStartedGraph,
+    buildNodeSizesGraph,
+    buildSpacingGraph,
+    buildWorkflowGraph,
+    graphOptionsSnippet,
+    rankdirOptions,
+} from './graphBuilders';
+import type {AttributeDefinition, DemoSettings, PageDefinition} from './types';
+
+const directionControls = [
+    {
+        type: 'segmented' as const,
+        label: 'rankdir',
+        key: 'rankdir' as const,
+        options: rankdirOptions(),
+    },
+];
+
+const alignOptions = [
+    {label: 'UL', value: 'UL'},
+    {label: 'UR', value: 'UR'},
+    {label: 'DL', value: 'DL'},
+    {label: 'DR', value: 'DR'},
+];
+
+const rankerOptions = [
+    {label: 'Network', value: 'network-simplex'},
+    {label: 'Tight', value: 'tight-tree'},
+    {label: 'Longest', value: 'longest-path'},
+];
+
+const acyclicerOptions = [
+    {label: 'Off', value: 'none'},
+    {label: 'Greedy', value: 'greedy'},
+];
+
+const labelPositionOptions = [
+    {label: 'Left', value: 'l'},
+    {label: 'Center', value: 'c'},
+    {label: 'Right', value: 'r'},
+];
+
+const graphAttributes: AttributeDefinition[] = [
+    {
+        target: 'graph',
+        name: 'rankdir',
+        defaultValue: 'TB',
+        description: 'Direction for rank nodes. Can be TB, BT, LR, or RL, where T = top, B = bottom, L = left, and R = right.',
+    },
+    {
+        target: 'graph',
+        name: 'align',
+        defaultValue: 'undefined',
+        description: 'Alignment for rank nodes. Can be UL, UR, DL, or DR, where U = up, D = down, L = left, and R = right.',
+    },
+    {
+        target: 'graph',
+        name: 'nodesep',
+        defaultValue: '50',
+        description: 'Number of pixels that separate nodes horizontally in the layout.',
+    },
+    {
+        target: 'graph',
+        name: 'edgesep',
+        defaultValue: '20',
+        description: 'Number of pixels that separate edges horizontally in the layout.',
+    },
+    {
+        target: 'graph',
+        name: 'ranksep',
+        defaultValue: '50',
+        description: 'Number of pixels between each rank in the layout.',
+    },
+    {
+        target: 'graph',
+        name: 'marginx',
+        defaultValue: '0',
+        description: 'Number of pixels to use as a margin around the left and right of the graph.',
+    },
+    {
+        target: 'graph',
+        name: 'marginy',
+        defaultValue: '0',
+        description: 'Number of pixels to use as a margin around the top and bottom of the graph.',
+    },
+    {
+        target: 'graph',
+        name: 'acyclicer',
+        defaultValue: 'undefined',
+        description: 'If set to greedy, uses a greedy heuristic for finding a feedback arc set for a graph.',
+    },
+    {
+        target: 'graph',
+        name: 'ranker',
+        defaultValue: 'network-simplex',
+        description: 'Type of algorithm to assign a rank to each node. Can be network-simplex, tight-tree, or longest-path.',
+    },
+];
+
+const nodeAttributes: AttributeDefinition[] = [
+    {
+        target: 'node',
+        name: 'width',
+        defaultValue: '0',
+        description: 'The width of the node in pixels.',
+    },
+    {
+        target: 'node',
+        name: 'height',
+        defaultValue: '0',
+        description: 'The height of the node in pixels.',
+    },
+];
+
+const edgeAttributes: AttributeDefinition[] = [
+    {
+        target: 'edge',
+        name: 'minlen',
+        defaultValue: '1',
+        description: 'The number of ranks to keep between the source and target of the edge.',
+    },
+    {
+        target: 'edge',
+        name: 'weight',
+        defaultValue: '1',
+        description: 'The weight to assign the edge. Higher weight edges are generally made shorter and straighter than lower weight edges.',
+    },
+    {
+        target: 'edge',
+        name: 'width',
+        defaultValue: '0',
+        description: 'The width of the edge label in pixels.',
+    },
+    {
+        target: 'edge',
+        name: 'height',
+        defaultValue: '0',
+        description: 'The height of the edge label in pixels.',
+    },
+    {
+        target: 'edge',
+        name: 'labelpos',
+        defaultValue: 'r',
+        description: 'Where to place the label relative to the edge. Can be l = left, c = center, or r = right.',
+    },
+    {
+        target: 'edge',
+        name: 'labeloffset',
+        defaultValue: '10',
+        description: 'How many pixels to move the label away from the edge. Applies only when labelpos is l or r.',
+    },
+];
+
+function gettingStartedCode(settings: DemoSettings): string {
+    return `import dagre from "@dagrejs/dagre";
+
+const g = new dagre.graphlib.Graph();
+
+${graphOptionsSnippet(settings)}
+g.setDefaultEdgeLabel(() => ({}));
+
+g.setNode("configure", {label: "Configure", width: 116, height: 44});
+g.setNode("build", {label: "Build graph", width: 118, height: 44});
+g.setNode("layout", {label: "Run layout", width: 112, height: 44});
+g.setNode("render", {label: "Render SVG", width: 112, height: 44});
+
+g.setEdge("configure", "build");
+g.setEdge("build", "layout");
+g.setEdge("layout", "render");
+
+dagre.layout(g);
+
+// D3 renders g.nodes(), g.edges(), and each edge's points.`;
+}
+
+export const pages: PageDefinition[] = [
+    {
+        id: 'getting-started',
+        navTitle: 'Getting Started',
+        eyebrow: 'Interactive docs',
+        title: 'Graph layout for JavaScript',
+        description: 'Build a directed graph, give Dagre node dimensions, run layout, and render the calculated positions with D3.',
+        sections: [
+            {
+                id: 'first-layout',
+                title: 'Your first layout',
+                body: [
+                    'Dagre computes positions for nodes and routing points for edges. The renderer can be SVG, Canvas, WebGL, or anything else that understands coordinates.',
+                    'This demo uses D3 for the SVG layer, the same general approach as the existing standalone demo.',
+                ],
+                demo: {
+                    id: 'getting-started-demo',
+                    title: 'Basic directed graph',
+                    caption: 'The graph is laid out by Dagre, then drawn with D3 paths, labels, and nodes.',
+                    initialSettings: {rankdir: 'TB', nodesep: 50, ranksep: 70, edgesep: 20},
+                    controls: directionControls,
+                    buildGraph: buildGettingStartedGraph,
+                    code: gettingStartedCode,
+                },
+            },
+            {
+                id: 'workflow',
+                title: 'A practical workflow',
+                body: [
+                    'Dagre is most useful when the graph is created from application data. This example has a branching approval flow and labeled edges.',
+                    'Changing direction keeps the graph semantics intact while Dagre recalculates the layout.',
+                ],
+                demo: {
+                    id: 'workflow-demo',
+                    title: 'Approval workflow',
+                    caption: 'A more realistic graph with branches, labels, and a longer path.',
+                    initialSettings: {rankdir: 'LR', nodesep: 44, ranksep: 80, edgesep: 18},
+                    controls: directionControls,
+                    buildGraph: buildWorkflowGraph,
+                    code: (settings) => `const g = new dagre.graphlib.Graph();
+
+${graphOptionsSnippet(settings)}
+g.setDefaultEdgeLabel(() => ({}));
+
+g.setNode("request", {label: "Request", width: 100, height: 44});
+g.setNode("approval", {label: "Approval", width: 104, height: 44});
+g.setNode("fulfill", {label: "Fulfill", width: 96, height: 44});
+g.setNode("reject", {label: "Reject", width: 92, height: 44});
+
+g.setEdge("approval", "fulfill", {label: "approved", width: 58, height: 20});
+g.setEdge("approval", "reject", {label: "denied", width: 48, height: 20});
+
+dagre.layout(g);`,
+                },
+            },
+        ],
+    },
+    {
+        id: 'attributes',
+        navTitle: 'Attributes',
+        eyebrow: 'Reference',
+        title: 'Layout attributes',
+        description: 'Set graph, node, and edge attributes before calling layout to control direction, spacing, ranking, sizing, and edge labels.',
+        sections: [
+            {
+                id: 'graph-attributes',
+                title: 'Graph attributes',
+                body: [
+                    'Graph attributes are set with g.setGraph(...). They configure the overall layout algorithm and graph canvas.',
+                ],
+                demo: {
+                    id: 'graph-attributes-demo',
+                    title: 'Graph attribute controls',
+                    caption: 'Adjust direction, rank alignment, spacing, margins, cycle handling, and ranking strategy.',
+                    initialSettings: {
+                        rankdir: 'LR',
+                        align: 'UL',
+                        nodesep: 48,
+                        ranksep: 76,
+                        edgesep: 18,
+                        marginx: 24,
+                        marginy: 24,
+                        ranker: 'network-simplex',
+                        acyclicer: 'greedy',
+                    },
+                    controls: [
+                        ...directionControls,
+                        {type: 'segmented', label: 'align', key: 'align', options: alignOptions},
+                        {type: 'segmented', label: 'ranker', key: 'ranker', options: rankerOptions},
+                        {type: 'segmented', label: 'acyclicer', key: 'acyclicer', options: acyclicerOptions},
+                        {type: 'range', label: 'nodesep', key: 'nodesep', min: 20, max: 120, step: 5},
+                        {type: 'range', label: 'ranksep', key: 'ranksep', min: 30, max: 160, step: 5},
+                        {type: 'range', label: 'edgesep', key: 'edgesep', min: 5, max: 80, step: 5},
+                        {type: 'range', label: 'marginx', key: 'marginx', min: 0, max: 80, step: 4},
+                        {type: 'range', label: 'marginy', key: 'marginy', min: 0, max: 80, step: 4},
+                    ],
+                    buildGraph: buildAttributeGraph,
+                    code: (settings) => `const g = new dagre.graphlib.Graph();
+
+${graphOptionsSnippet(settings)}
+
+// Add nodes and edges, then run layout.
+dagre.layout(g);`,
+                },
+                attributes: graphAttributes,
+            },
+            {
+                id: 'node-attributes',
+                title: 'Node attributes',
+                body: [
+                    'Node attributes are set with g.setNode(id, ...). Width and height should describe the rendered node before layout runs.',
+                ],
+                demo: {
+                    id: 'node-attributes-demo',
+                    title: 'Node size controls',
+                    caption: 'Switch node dimensions and observe how Dagre preserves spacing around each measured box.',
+                    initialSettings: {rankdir: 'LR', nodesep: 52, ranksep: 84, edgesep: 18, nodeSize: 'mixed'},
+                    controls: [
+                        ...directionControls,
+                        {
+                            type: 'segmented',
+                            label: 'size',
+                            key: 'nodeSize',
+                            options: [
+                                {label: 'Compact', value: 'compact'},
+                                {label: 'Mixed', value: 'mixed'},
+                                {label: 'Wide', value: 'wide'},
+                            ],
+                        },
+                    ],
+                    buildGraph: buildNodeSizesGraph,
+                    code: (settings) => `g.setNode("parser", {
+  label: "Parse and normalize",
+  width: ${settings.nodeSize === 'compact' ? 86 : 164},
+  height: 44
+});
+
+g.setNode("rules", {
+  label: "Apply business validation rules",
+  width: ${settings.nodeSize === 'wide' ? 238 : 92},
+  height: ${settings.nodeSize === 'compact' ? 44 : 52}
+});
+
+dagre.layout(g);`,
+                },
+                attributes: nodeAttributes,
+            },
+            {
+                id: 'edge-attributes',
+                title: 'Edge attributes',
+                body: [
+                    'Edge attributes are set with g.setEdge(source, target, ...). They influence rank distance, edge straightness, and label placement.',
+                ],
+                demo: {
+                    id: 'edge-attributes-demo',
+                    title: 'Edge attribute controls',
+                    caption: 'Change rank distance, edge weight, label size, label side, and label offset before layout runs.',
+                    initialSettings: {
+                        rankdir: 'LR',
+                        nodesep: 54,
+                        ranksep: 90,
+                        edgesep: 22,
+                        minlen: 1,
+                        weight: 10,
+                        labelpos: 'r',
+                        labeloffset: 10,
+                        labelWidth: 72,
+                    },
+                    controls: [
+                        ...directionControls,
+                        {type: 'segmented', label: 'labelpos', key: 'labelpos', options: labelPositionOptions},
+                        {type: 'range', label: 'minlen', key: 'minlen', min: 1, max: 4, step: 1},
+                        {type: 'range', label: 'weight', key: 'weight', min: 5, max: 25, step: 5},
+                        {type: 'range', label: 'label width', key: 'labelWidth', min: 40, max: 140, step: 4},
+                        {type: 'range', label: 'labeloffset', key: 'labeloffset', min: 0, max: 40, step: 2},
+                    ],
+                    buildGraph: buildEdgeAttributesGraph,
+                    code: (settings) => `g.setGraph({rankdir: "${settings.rankdir ?? 'LR'}"});
+
+g.setEdge("source", "main", {
+  label: "controlled",
+  width: ${settings.labelWidth ?? 72},
+  height: 24,
+  minlen: ${settings.minlen ?? 1},
+  weight: ${settings.weight ?? 1},
+  labelpos: "${settings.labelpos ?? 'r'}",
+  labeloffset: ${settings.labeloffset ?? 10}
+});
+
+g.setEdge("source", "alternate", {
+  label: "other",
+  weight: ${Math.max(1, 26 - (settings.weight ?? 10))}
+});
+
+g.setEdge("main", "sink", {
+  label: "finish",
+  width: ${settings.labelWidth ?? 72},
+  height: 24,
+  minlen: ${settings.minlen ?? 1},
+  weight: ${settings.weight ?? 1},
+  labelpos: "${settings.labelpos ?? 'r'}",
+  labeloffset: ${settings.labeloffset ?? 10}
+});
+
+dagre.layout(g);`,
+                },
+                attributes: edgeAttributes,
+            },
+        ],
+    },
+    {
+        id: 'layout-direction',
+        navTitle: 'Layout Direction',
+        eyebrow: 'Configuration',
+        title: 'Change graph direction',
+        description: 'Use rankdir to choose whether ranks flow top-to-bottom, bottom-to-top, left-to-right, or right-to-left.',
+        sections: [
+            {
+                id: 'rankdir',
+                title: 'rankdir',
+                body: [
+                    'The same graph can be laid out in four directions. This is useful when matching a workflow, dependency graph, or diagram to the available screen space.',
+                ],
+                demo: {
+                    id: 'rankdir-demo',
+                    title: 'Direction control',
+                    caption: 'Switch directions and watch Dagre recalculate the node positions and edge points.',
+                    initialSettings: {rankdir: 'LR', nodesep: 48, ranksep: 76, edgesep: 18},
+                    controls: directionControls,
+                    buildGraph: buildSpacingGraph,
+                    code: (settings) => `const g = new dagre.graphlib.Graph();
+
+g.setGraph({
+  rankdir: "${settings.rankdir ?? 'LR'}"
+});
+
+// Add nodes and edges, then run layout.
+dagre.layout(g);`,
+                },
+            },
+        ],
+    },
+    {
+        id: 'spacing',
+        navTitle: 'Spacing',
+        eyebrow: 'Configuration',
+        title: 'Tune spacing',
+        description: 'Dagre exposes graph-level spacing options that control how much room appears between nodes, ranks, and edges.',
+        sections: [
+            {
+                id: 'spacing-options',
+                title: 'nodesep, ranksep, edgesep',
+                body: [
+                    'Spacing settings are graph-level options. They are especially important when node labels are long or dense graphs need more breathing room.',
+                ],
+                demo: {
+                    id: 'spacing-demo',
+                    title: 'Spacing controls',
+                    caption: 'Adjust the sliders to update graph options before calling dagre.layout.',
+                    initialSettings: {rankdir: 'TB', nodesep: 50, ranksep: 70, edgesep: 20},
+                    controls: [
+                        ...directionControls,
+                        {type: 'range', label: 'nodesep', key: 'nodesep', min: 20, max: 120, step: 5},
+                        {type: 'range', label: 'ranksep', key: 'ranksep', min: 30, max: 160, step: 5},
+                        {type: 'range', label: 'edgesep', key: 'edgesep', min: 5, max: 80, step: 5},
+                    ],
+                    buildGraph: buildSpacingGraph,
+                    code: (settings) => `const g = new dagre.graphlib.Graph();
+
+${graphOptionsSnippet(settings)}
+
+dagre.layout(g);`,
+                },
+            },
+        ],
+    },
+    {
+        id: 'node-sizes',
+        navTitle: 'Node Sizes',
+        eyebrow: 'Input data',
+        title: 'Give Dagre real dimensions',
+        description: 'Dagre needs the width and height of every node before layout so it can avoid overlaps and route edges around boxes.',
+        sections: [
+            {
+                id: 'dimensions',
+                title: 'Node dimensions',
+                body: [
+                    'Measure or decide each node size before calling layout. The calculated x and y values represent the center of each node.',
+                ],
+                demo: {
+                    id: 'node-sizes-demo',
+                    title: 'Mixed node sizes',
+                    caption: 'Different dimensions produce different routing while keeping the same graph structure.',
+                    initialSettings: {rankdir: 'LR', nodesep: 52, ranksep: 84, edgesep: 18, nodeSize: 'mixed'},
+                    controls: [
+                        ...directionControls,
+                        {
+                            type: 'segmented',
+                            label: 'size',
+                            key: 'nodeSize',
+                            options: [
+                                {label: 'Compact', value: 'compact'},
+                                {label: 'Mixed', value: 'mixed'},
+                                {label: 'Wide', value: 'wide'},
+                            ],
+                        },
+                    ],
+                    buildGraph: buildNodeSizesGraph,
+                    code: (settings) => `g.setNode("parser", {
+  label: "Parse and normalize",
+  width: ${settings.nodeSize === 'compact' ? 86 : 164},
+  height: 44
+});
+
+g.setNode("rules", {
+  label: "Apply business validation rules",
+  width: ${settings.nodeSize === 'wide' ? 238 : 92},
+  height: ${settings.nodeSize === 'compact' ? 44 : 52}
+});
+
+dagre.layout(g);`,
+                },
+            },
+        ],
+    },
+    {
+        id: 'edge-labels',
+        navTitle: 'Edge Labels',
+        eyebrow: 'Rendering',
+        title: 'Render edge labels and paths',
+        description: 'Dagre returns edge points and label coordinates. D3 can turn those points into SVG paths and position labels.',
+        sections: [
+            {
+                id: 'labels',
+                title: 'Labeled edges',
+                body: [
+                    'Set edge label dimensions before layout. After layout, use the edge points for the path and the edge x/y values for the label.',
+                ],
+                demo: {
+                    id: 'edge-labels-demo',
+                    title: 'Review flow',
+                    caption: 'Labels are part of the layout, so routed edges leave space for them.',
+                    initialSettings: {rankdir: 'LR', nodesep: 54, ranksep: 90, edgesep: 22},
+                    controls: directionControls,
+                    buildGraph: buildEdgeLabelsGraph,
+                    code: (settings) => `g.setGraph({rankdir: "${settings.rankdir ?? 'LR'}"});
+
+g.setEdge("draft", "review", {
+  label: "submit",
+  width: 48,
+  height: 20
+});
+
+dagre.layout(g);
+
+const edge = g.edge("draft", "review");
+// edge.points is rendered as a D3 line.
+// edge.x and edge.y position the label.`,
+                },
+            },
+        ],
+    },
+];

--- a/website/src/content/types.ts
+++ b/website/src/content/types.ts
@@ -1,0 +1,76 @@
+import type {Graph} from '@dagrejs/graphlib';
+import type {EdgeLabel, GraphLabel, NodeLabel} from '@dagrejs/dagre';
+
+export type RankDirection = 'TB' | 'BT' | 'LR' | 'RL';
+export type RankAlignment = 'UL' | 'UR' | 'DL' | 'DR';
+export type Ranker = 'network-simplex' | 'tight-tree' | 'longest-path';
+export type Acyclicer = 'none' | 'greedy';
+export type LabelPosition = 'l' | 'c' | 'r';
+
+export type DemoSettings = {
+    rankdir?: RankDirection;
+    align?: RankAlignment;
+    nodesep?: number;
+    ranksep?: number;
+    edgesep?: number;
+    marginx?: number;
+    marginy?: number;
+    ranker?: Ranker;
+    acyclicer?: Acyclicer;
+    nodeSize?: 'compact' | 'mixed' | 'wide';
+    minlen?: number;
+    weight?: number;
+    labelpos?: LabelPosition;
+    labeloffset?: number;
+    labelWidth?: number;
+};
+
+export type Control =
+    | {
+        type: 'segmented';
+        label: string;
+        key: keyof DemoSettings;
+        options: Array<{label: string; value: string}>;
+    }
+    | {
+        type: 'range';
+        label: string;
+        key: keyof DemoSettings;
+        min: number;
+        max: number;
+        step: number;
+    };
+
+export type DemoDefinition = {
+    id: string;
+    title: string;
+    caption: string;
+    initialSettings: DemoSettings;
+    controls: Control[];
+    buildGraph: (settings: DemoSettings) => Graph<GraphLabel, NodeLabel, EdgeLabel>;
+    code: (settings: DemoSettings) => string;
+};
+
+export type AttributeDefinition = {
+    target: 'graph' | 'node' | 'edge';
+    name: string;
+    defaultValue: string;
+    description: string;
+};
+
+export type PageSection = {
+    id: string;
+    title: string;
+    body: string[];
+    demo?: DemoDefinition;
+    attributes?: AttributeDefinition[];
+};
+
+export type PageDefinition = {
+    id: string;
+    navTitle: string;
+    eyebrow: string;
+    title: string;
+    description: string;
+    sections: PageSection[];
+};

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+import {App} from './App';
+import './styles.css';
+
+const root = document.getElementById('root');
+
+if (!root) {
+    throw new Error('Missing root element');
+}
+
+createRoot(root).render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>,
+);

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -1,0 +1,710 @@
+html {
+    scroll-padding-top: 6rem;
+}
+
+:root {
+    color: #dcdfec;
+    background: #1f2028;
+    font-family:
+        Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+        sans-serif;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-width: 320px;
+    background: #1f2028;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+button,
+input {
+    font: inherit;
+}
+
+.app-shell {
+    min-height: 100vh;
+    background: #1f2028;
+}
+
+.topbar {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 22rem;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    height: 64px;
+    padding: 0 2rem;
+    border-bottom: 1px solid rgb(45 46 58 / 90%);
+    background: rgb(31 32 40 / 90%);
+    backdrop-filter: blur(16px);
+}
+
+.topbar-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #dcdfec;
+    font-size: 14px;
+    font-weight: 650;
+}
+
+.version-pill {
+    display: inline-flex;
+    align-items: center;
+    height: 2.25rem;
+    padding: 0 0.8rem;
+    border-radius: 0.5rem;
+    color: #ffffff;
+    background: #f43f5e;
+    font-size: 0.9rem;
+    font-weight: 800;
+}
+
+.icon-button {
+    display: inline-grid;
+    place-items: center;
+    width: 38px;
+    height: 38px;
+    border: 1px solid #575969;
+    border-radius: 7px;
+    color: #dcdfec;
+    background: #272935;
+    cursor: pointer;
+}
+
+.nav-toggle,
+.mobile-only {
+    display: none;
+}
+
+.docs-frame {
+    display: block;
+    min-height: 100vh;
+    padding: 0 18rem 5rem 22rem;
+}
+
+.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 50;
+    height: 100%;
+    width: 22rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border-right: 1px solid #272935;
+    color: #f3f4f8;
+    background: #1f2028;
+    font-family:
+        Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+        "Segoe UI", sans-serif;
+    outline: none;
+    box-shadow: none;
+    will-change: transform;
+}
+
+.sidebar-gradient {
+    position: sticky;
+    top: 0;
+    z-index: -1;
+    width: 100%;
+    height: 25rem;
+    margin-bottom: -25rem;
+    background:
+        linear-gradient(
+            195deg,
+            hsl(348deg 10% 90%) 0%,
+            hsl(351deg 31% 80%) 2%,
+            hsl(325deg 45% 69%) 6%,
+            hsl(330deg 32% 57%) 12%,
+            hsl(320deg 22% 48%) 19%,
+            hsl(285deg 22% 33%) 27%,
+            hsl(240deg 20% 22%) 38%,
+            hsl(232deg 18% 17%) 50%,
+            hsl(232deg 13% 14%) 68%,
+            hsl(233deg 15% 14%) 100%
+        );
+}
+
+.sidebar-container {
+    margin: 0 auto 2rem;
+}
+
+.sidebar-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.75rem 2.5rem 4.5rem;
+}
+
+.sidebar-wordmark {
+    display: inline-flex;
+    align-items: center;
+    color: #ffffff;
+    font-size: 2rem;
+    font-weight: 850;
+    line-height: 1;
+}
+
+.nav-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin: 1rem 0 0;
+    padding: 0 2.5rem;
+    overflow: hidden;
+    list-style: none;
+    font-size: 1.125rem;
+}
+
+.nav-list li {
+    display: inline-block;
+    width: 100%;
+    scroll-margin-top: 10rem;
+}
+
+.nav-list a {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    height: 3rem;
+    margin: 0 -1rem;
+    padding: 0 0.75rem;
+    border-radius: 0.5rem;
+    color: #dcdfec;
+    font-size: 1.125rem;
+    font-weight: 600;
+    overflow: hidden;
+    overflow-wrap: anywhere;
+}
+
+.nav-list a span {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nav-list a:hover {
+    color: #ffffff;
+    background: rgb(196 181 253 / 10%);
+}
+
+.nav-list a.active {
+    color: #f472b6;
+    background: rgb(244 114 182 / 10%);
+    font-weight: 800;
+}
+
+.nav-scrim {
+    display: none;
+}
+
+.content {
+    width: min(100%, 50rem);
+    min-width: 0;
+    margin: 0 auto;
+    padding: 6rem 2rem 0;
+}
+
+.page-card {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 3rem;
+    padding: 3rem;
+    border: 1px solid #2d2e3a;
+    border-radius: 1rem;
+    background: #272935;
+    box-shadow: none;
+}
+
+.page-card-icon {
+    display: none;
+    place-items: center;
+    width: 7rem;
+    height: 7rem;
+    border-radius: 999px;
+    color: #ffffff;
+    background:
+        radial-gradient(circle at 30% 20%, rgb(255 255 255 / 45%), transparent 25%),
+        linear-gradient(135deg, #fb7185, #ec4899 52%, #8b5cf6);
+    box-shadow: 0 24px 44px rgb(236 72 153 / 26%);
+    font-size: 3rem;
+    font-weight: 850;
+}
+
+.eyebrow {
+    margin: 0 0 12px;
+    color: #e11d48;
+    font-size: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+    overflow-wrap: anywhere;
+}
+
+h1 {
+    max-width: 760px;
+    margin: 0;
+    color: #ffffff;
+    font-size: 3.5rem;
+    line-height: 1.1;
+}
+
+.lead {
+    max-width: 760px;
+    margin: 18px 0 0;
+    color: #c4b5fd;
+    font-size: 1.075rem;
+    line-height: 1.75;
+}
+
+.doc-section {
+    display: grid;
+    gap: 20px;
+    margin-bottom: 3.25rem;
+    scroll-margin-top: 6rem;
+}
+
+.section-copy {
+    max-width: 760px;
+}
+
+.section-copy h2 {
+    margin: 0 0 12px;
+    color: #ffffff;
+    font-size: 2rem;
+}
+
+.section-copy p {
+    margin: 0 0 12px;
+    color: #bfc3d9;
+    font-size: 1.075rem;
+    line-height: 1.7;
+}
+
+.demo-block {
+    overflow: hidden;
+    border: 1px solid #2d2e3a;
+    border-radius: 0.75rem;
+    background: #272935;
+    box-shadow: none;
+}
+
+.demo-block::before {
+    content: "";
+    display: block;
+    height: 3rem;
+    border-bottom: 1px solid #2d2e3a;
+    background:
+        radial-gradient(circle at 1.75rem 50%, #ec695e 0 0.38rem, transparent 0.42rem),
+        radial-gradient(circle at 3.15rem 50%, #f4bf4f 0 0.38rem, transparent 0.42rem),
+        radial-gradient(circle at 4.55rem 50%, #61c653 0 0.38rem, transparent 0.42rem),
+        rgb(87 89 105 / 60%);
+}
+
+.demo-heading {
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) auto;
+    gap: 18px;
+    align-items: start;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid #2d2e3a;
+    background: #272935;
+}
+
+.demo-heading h3 {
+    margin: 0 0 6px;
+    color: #ffffff;
+    font-size: 17px;
+}
+
+.demo-heading p {
+    margin: 0;
+    color: #b0b2c3;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.demo-controls {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.segmented-control,
+.range-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #b0b2c3;
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.segmented-control > div {
+    display: flex;
+    padding: 3px;
+    border: 1px solid #575969;
+    border-radius: 0.5rem;
+    background: #1f2028;
+}
+
+.segmented-control button {
+    min-width: 40px;
+    height: 30px;
+    border: 0;
+    border-radius: 0.375rem;
+    color: #dcdfec;
+    background: transparent;
+    cursor: pointer;
+    font-weight: 750;
+}
+
+.segmented-control button.selected {
+    color: #ffffff;
+    background: linear-gradient(135deg, #e11d48, #ec4899);
+    box-shadow: 0 5px 12px rgb(225 29 72 / 24%);
+}
+
+.range-control {
+    min-width: 172px;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.range-control span {
+    display: flex;
+    justify-content: space-between;
+}
+
+.range-control strong {
+    color: #ffffff;
+}
+
+.range-control input {
+    width: 100%;
+    accent-color: #e11d48;
+}
+
+.graph-stage {
+    height: 430px;
+    background:
+        linear-gradient(#2d2e3a 1px, transparent 1px),
+        linear-gradient(90deg, #2d2e3a 1px, transparent 1px),
+        #1f2028;
+    background-size: 24px 24px;
+}
+
+.graph-stage svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+}
+
+.edge-path {
+    fill: none;
+    stroke: #b0b2c3;
+    stroke-width: 1.8;
+}
+
+.edge-path.focus {
+    stroke: #f472b6;
+}
+
+.edge-label rect {
+    fill: #272935;
+    stroke: #575969;
+    stroke-width: 1.2;
+}
+
+.edge-label.focus rect {
+    fill: rgb(244 114 182 / 13%);
+    stroke: #f472b6;
+}
+
+.edge-label text {
+    fill: #dcdfec;
+    font-size: 12px;
+    font-weight: 750;
+}
+
+.node rect {
+    fill: #272935;
+    stroke: #575969;
+    stroke-width: 1.5;
+    filter: drop-shadow(0 7px 14px rgb(15 23 42 / 10%));
+}
+
+.node text {
+    fill: #ffffff;
+    font-size: 13px;
+    font-weight: 760;
+    pointer-events: none;
+}
+
+.node.accent rect {
+    fill: rgb(244 114 182 / 13%);
+    stroke: #f472b6;
+}
+
+.node.success rect {
+    fill: rgb(16 185 129 / 14%);
+    stroke: #34d399;
+}
+
+.node.warning rect {
+    fill: rgb(251 146 60 / 16%);
+    stroke: #fb923c;
+}
+
+.code-block {
+    margin: 0;
+    max-height: 360px;
+    overflow: auto;
+    padding: 18px;
+    border-top: 1px solid #2d2e3a;
+    color: #c8d3f5;
+    background: #272935;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    font-size: 13px;
+    line-height: 1.7;
+}
+
+.attribute-table-wrap {
+    overflow-x: auto;
+    border: 1px solid #2d2e3a;
+    border-radius: 0.75rem;
+    background: #272935;
+}
+
+.attribute-table {
+    width: 100%;
+    min-width: 680px;
+    border-collapse: collapse;
+    color: #dcdfec;
+    font-size: 14px;
+    line-height: 1.55;
+}
+
+.attribute-table th,
+.attribute-table td {
+    padding: 14px 16px;
+    border-bottom: 1px solid #2d2e3a;
+    text-align: left;
+    vertical-align: top;
+}
+
+.attribute-table th {
+    color: #ffffff;
+    background: #1f2028;
+    font-size: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.attribute-table tr:last-child td {
+    border-bottom: 0;
+}
+
+.attribute-table td:first-child {
+    color: #f472b6;
+    font-weight: 800;
+}
+
+.attribute-table code {
+    color: #c8d3f5;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    font-size: 13px;
+}
+
+.site-footer {
+    margin: 4rem 0 0;
+    padding: 2rem 0 0;
+    border-top: 1px solid #2d2e3a;
+    color: #7f8497;
+    text-align: center;
+    font-size: 0.95rem;
+}
+
+.site-footer p {
+    margin: 0 0 0.75rem;
+}
+
+.site-footer a {
+    color: #f472b6;
+    font-weight: 750;
+    text-decoration: underline;
+    text-underline-offset: 4px;
+}
+
+.toc {
+    position: fixed;
+    top: 5.25rem;
+    right: 0;
+    display: grid;
+    gap: 8px;
+    width: 18rem;
+    max-height: 100vh;
+    overflow-y: auto;
+    padding: 0 2rem 2rem;
+    color: #b0b2c3;
+    font-size: 13px;
+}
+
+.toc span {
+    margin-bottom: 5px;
+    color: #575969;
+    font-size: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.toc a {
+    padding: 0.35rem 0;
+    color: #dcdfec;
+    font-size: 1.1rem;
+}
+
+.toc a:hover {
+    color: #e11d48;
+}
+
+@media (max-width: 1120px) {
+    .topbar {
+        left: 16rem;
+    }
+
+    .docs-frame {
+        padding-left: 16rem;
+        padding-right: 0;
+    }
+
+    .sidebar {
+        width: 16rem;
+    }
+
+    .sidebar-top {
+        padding-inline: 1.5rem;
+    }
+
+    .nav-list {
+        padding-inline: 1.5rem;
+    }
+
+    .toc {
+        display: none;
+    }
+}
+
+@media (max-width: 820px) {
+    .topbar {
+        left: 0;
+        padding: 0 16px;
+    }
+
+    .version-pill {
+        display: none;
+    }
+
+    .nav-toggle {
+        display: inline-grid;
+        margin-left: auto;
+    }
+
+    .topbar-link {
+        margin-left: 0;
+    }
+
+    .docs-frame {
+        display: block;
+        padding: 0 0 48px;
+    }
+
+    .sidebar {
+        z-index: 50;
+        width: min(90%, 20rem);
+        border-right: 1px solid #272935;
+        background: #1f2028;
+        transform: translateX(-100%);
+        transition: transform 160ms ease;
+    }
+
+    .sidebar.is-open {
+        transform: translateX(0);
+    }
+
+    .mobile-only {
+        display: inline-grid;
+    }
+
+    .nav-scrim {
+        position: fixed;
+        inset: 0;
+        z-index: 40;
+        display: block;
+        border: 0;
+        background: rgb(0 0 0 / 45%);
+        cursor: pointer;
+    }
+
+    .page-card {
+        grid-template-columns: 1fr;
+        padding: 22px;
+    }
+
+    .page-card-icon {
+        width: 72px;
+        height: 72px;
+        font-size: 32px;
+    }
+
+    h1 {
+        font-size: 34px;
+    }
+
+    .content {
+        padding: 5.5rem 1rem 0;
+    }
+
+    .lead {
+        font-size: 16px;
+    }
+
+    .demo-heading {
+        grid-template-columns: 1fr;
+    }
+
+    .demo-controls {
+        justify-content: flex-start;
+    }
+
+    .graph-stage {
+        height: 360px;
+    }
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "allowImportingTsExtensions": true,
+        "declaration": false,
+        "declarationMap": false,
+        "jsx": "react-jsx",
+        "noEmit": true,
+        "types": ["vite/client"],
+        "baseUrl": ".",
+        "paths": {
+            "@dagrejs/dagre": ["../index.ts"]
+        }
+    },
+    "include": ["src/**/*", "vite.config.ts"]
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,0 +1,20 @@
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repositoryName = process.env.GITHUB_REPOSITORY?.split('/')[1];
+
+export default defineConfig({
+    base: process.env.GITHUB_ACTIONS && repositoryName ? `/${repositoryName}/` : '/',
+    plugins: [react()],
+    resolve: {
+        alias: {
+            '@dagrejs/dagre': path.resolve(dirname, '../index.ts'),
+        },
+    },
+    server: {
+        port: 5173,
+    },
+});


### PR DESCRIPTION
This pull request introduces a new documentation website for the project, including a full-featured interactive demo system. The changes add a Vite-based React app under the `website/` directory, implement several React components for demos and documentation, and set up a GitHub Actions workflow for automated deployment to GitHub Pages. Supporting files for project configuration and build are also included.

Key changes:

**Documentation website setup:**

* Added a new `website/` directory containing a Vite + React application with dependencies and scripts defined in `package.json`. This includes setup for development, build, and preview commands, as well as all necessary dependencies for building the websiteand running interactive demos.
* Added an `.gitignore` in `website/` to exclude build artifacts, dependencies, and temporary files from version control.
* Created an `index.html` entry point for the documentation site, mounting the React app.

**Interactive documentation and demo system:**

* Implemented the main `App` component (`website/src/App.tsx`) to provide navigation, page layout, and rendering of documentation content and interactive demos.
* Developed a suite of React components for the demo system:
  - `InteractiveDemo` for rendering individual interactive demos with controls and code samples.
  - `D3DagreDemo` for rendering Dagre graphs using D3 and Dagre libraries.
  - `DemoControls` for user interaction with demo parameters.
  - `CodeBlock` for displaying code snippets.

**Deployment automation:**

* Added a GitHub Actions workflow (`.github/workflows/pages.yml`) to automate building and deploying the documentation site to GitHub Pages on pushes to the `master` branch.


The current result demo can be found here: https://wandri.github.io/dagre-ts/